### PR TITLE
upgraded embulk 0.4.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ configurations {
 version = "0.1.0"
 
 dependencies {
-    compile  "org.embulk:embulk-core:0.4.0"
-    provided "org.embulk:embulk-core:0.4.0"
+    compile  "org.embulk:embulk-core:0.4.2"
+    provided "org.embulk:embulk-core:0.4.2"
     compile "com.amazonaws:aws-java-sdk-s3:1.9.17"
     testCompile "junit:junit:4.+"
     testCompile "org.mockito:mockito-core:1.+"

--- a/src/main/java/org/embulk/input/s3/S3FileInputPlugin.java
+++ b/src/main/java/org/embulk/input/s3/S3FileInputPlugin.java
@@ -13,12 +13,12 @@ import java.nio.file.FileVisitResult;
 import java.nio.file.attribute.BasicFileAttributes;
 import javax.validation.constraints.NotNull;
 import com.google.common.collect.ImmutableList;
-import com.fasterxml.jackson.annotation.JacksonInject;
 import org.embulk.config.Config;
 import org.embulk.config.Task;
 import org.embulk.config.TaskSource;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.ConfigDiff;
+import org.embulk.config.ConfigInject;
 import org.embulk.config.CommitReport;
 import org.embulk.spi.BufferAllocator;
 import org.embulk.spi.Exec;
@@ -92,7 +92,7 @@ public class S3FileInputPlugin
         public List<String> getFiles();
         public void setFiles(List<String> files);
 
-        @JacksonInject
+        @ConfigInject
         public BufferAllocator getBufferAllocator();
     }
 

--- a/src/test/java/org/embulk/input/s3/TestS3FileInputPlugin.java
+++ b/src/test/java/org/embulk/input/s3/TestS3FileInputPlugin.java
@@ -1,4 +1,4 @@
-package org.embulk.plugin.s3;
+package org.embulk.input.s3;
 
 import static org.junit.Assert.*;
 import java.util.List;


### PR DESCRIPTION
Embulk 0.4.2 doesn't use current embulk-plugin-s3 gem because `JacksonInject` was renamed to `ConfongInject`. If the pull req looks good to you, please release new version of embulk-plugin-s3.