### PR TITLE
Set last_path to ConfigDiff in transaction()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *~
+*.iml
 .idea
 build/
 /classpath/

--- a/src/main/java/org/embulk/input/s3/S3FileInputPlugin.java
+++ b/src/main/java/org/embulk/input/s3/S3FileInputPlugin.java
@@ -86,7 +86,11 @@ public class S3FileInputPlugin
             FileInputPlugin.Control control)
     {
         control.run(taskSource, taskCount);
-        return Exec.newConfigDiff();
+
+        PluginTask task = taskSource.loadTask(PluginTask.class);
+        ConfigDiff configDiff = Exec.newConfigDiff();
+        configDiff.set("last_path", task.getFiles().get(taskCount - 1));
+        return configDiff;
     }
 
     @Override

--- a/src/main/java/org/embulk/input/s3/S3FileInputPlugin.java
+++ b/src/main/java/org/embulk/input/s3/S3FileInputPlugin.java
@@ -74,10 +74,14 @@ public class S3FileInputPlugin
         PluginTask task = config.loadConfig(PluginTask.class);
 
         // list files recursively
-        task.setFiles(listFiles(task));
+        List<String> files = listFiles(task);
+        task.setFiles(files);
 
         // number of processors is same with number of files
-        return resume(task.dump(), task.getFiles().size(), control);
+        int taskCount = files.size();
+        ConfigDiff configDiff = resume(task.dump(), taskCount, control);
+        configDiff.set("last_path", files.get(taskCount - 1));
+        return configDiff;
     }
 
     @Override

--- a/src/main/java/org/embulk/input/s3/S3FileInputPlugin.java
+++ b/src/main/java/org/embulk/input/s3/S3FileInputPlugin.java
@@ -74,14 +74,10 @@ public class S3FileInputPlugin
         PluginTask task = config.loadConfig(PluginTask.class);
 
         // list files recursively
-        List<String> files = listFiles(task);
-        task.setFiles(files);
+        task.setFiles(listFiles(task));
 
         // number of processors is same with number of files
-        int taskCount = files.size();
-        ConfigDiff configDiff = resume(task.dump(), taskCount, control);
-        configDiff.set("last_path", files.get(taskCount - 1));
-        return configDiff;
+        return resume(task.dump(), task.getFiles().size(), control);
     }
 
     @Override


### PR DESCRIPTION
I fixed the transaction method to set last_path to ConfigDiff. Could you review my change?

Or What do you think about introducing AbstractFileInputPlugin? It's a abstract superclass of S3FileInputPlugin and LocalFileInputPlugin. Since the fixing should be applied to LocalFileInputPlugin, we can implement the transaction method in the superclass.