### PR TITLE
fixed ArrayIndexOutOfBoundsException handling

### DIFF
--- a/src/main/java/org/embulk/input/s3/S3FileInputPlugin.java
+++ b/src/main/java/org/embulk/input/s3/S3FileInputPlugin.java
@@ -100,8 +100,12 @@ public class S3FileInputPlugin
 
         List<String> files = new ArrayList<String>(task.getFiles());
         Collections.sort(files);
-        return Exec.newConfigDiff().
-            set("last_path", files.get(files.size() - 1));
+
+        ConfigDiff configDiff = Exec.newConfigDiff();
+        if (!files.isEmpty()) {
+            configDiff.set("last_path", files.get(files.size() - 1));
+        }
+        return configDiff;
     }
 
     @Override


### PR DESCRIPTION
The ArrayIndexOutOfBoundsException occurs if the files is empty.
```
Caused by: java.lang.ArrayIndexOutOfBoundsException: -1
    at java.util.ArrayList.elementData(ArrayList.java:400)
    at java.util.ArrayList.get(ArrayList.java:413)
    at org.embulk.input.s3.S3FileInputPlugin.resume(S3FileInputPlugin.java:103)
    at org.embulk.input.s3.S3FileInputPlugin.transaction(S3FileInputPlugin.java:89)
    at org.embulk.spi.FileInputRunner.transaction(FileInputRunner.java:63)
    at org.embulk.exec.LocalExecutor.doRun(LocalExecutor.java:431)
    at org.embulk.exec.LocalExecutor.access$000(LocalExecutor.java:40)
    at org.embulk.exec.LocalExecutor$1.run(LocalExecutor.java:359)
    at org.embulk.exec.LocalExecutor$1.run(LocalExecutor.java:355)
    at org.embulk.spi.Exec.doWith(Exec.java:21)
    at org.embulk.exec.LocalExecutor.run(LocalExecutor.java:355)
     ... 7 more
```