### PR TITLE
Add CredentialsProvider Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@
 - **bucket** S3 bucket name (string, required)
 - **path_prefix** prefix of target keys (string, required)
 - **endpoint** S3 endpoint login user name (string, optional)
-- **access_key_id** AWS access key id (string, required)
-- **secret_access_key** AWS secret key (string, required)
+- **access_key_id** AWS access key id (string, required if no `credential_provider` given)
+- **secret_access_key** AWS secret key (string, required if no `credential_provider` given)
+- **credential_provider** (string, optional)
 
 ## Example
 
@@ -25,6 +26,21 @@ in:
   access_key_id: ABCXYZ123ABCXYZ123
   secret_access_key: AbCxYz123aBcXyZ123
 ```
+
+### Credentials Provider
+
+Also Credentials provider can be specified with `credential_provider`.
+
+See [Providing AWS Credentials in the AWS SDK for Java](http://docs.aws.amazon.com/en_us/AWSSdkDocsJava/latest//DeveloperGuide/credentials.html) for details of each provider.
+
+provider | type
+-------- | -----
+Default(looks for credentials in the follwing  order:  env -> system -> profile -> instance)  | default
+Java System Property | system
+Environment Variable | env
+Profile | profile
+Instance Profile | instance
+
 
 ## Build
 

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/AWSCredentialProviders.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/AWSCredentialProviders.java
@@ -1,0 +1,78 @@
+package org.embulk.input.s3;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.auth.*;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.google.common.base.Optional;
+
+import java.util.HashMap;
+
+
+public enum AWSCredentialProviders {
+
+    SYSTEM_PROPERTY("system") {
+
+        @Override
+        public AWSCredentialsProvider createProvider() {
+            return new SystemPropertiesCredentialsProvider();
+        }
+    },
+    ENV("env") {
+
+        @Override
+        public AWSCredentialsProvider createProvider() {
+            return new EnvironmentVariableCredentialsProvider();
+        }
+    },
+    INSTANCE_PROFILE("instance") {
+        @Override
+        public AWSCredentialsProvider createProvider() {
+            return new InstanceProfileCredentialsProvider();
+        }
+    }, PROFILE("profile") {
+        @Override
+        public AWSCredentialsProvider createProvider() {
+            return new ProfileCredentialsProvider();
+        }
+    },
+    DEFAULT("default"){
+        @Override
+        public AWSCredentialsProvider createProvider() {
+            return new AWSCredentialsProviderChain(
+                    new EnvironmentVariableCredentialsProvider(),
+                    new SystemPropertiesCredentialsProvider(),
+                    new ProfileCredentialsProvider(),
+                    new InstanceProfileCredentialsProvider()) {
+
+                public AWSCredentials getCredentials() {
+                    try {
+                        return super.getCredentials();
+                    } catch (AmazonClientException ace) {}
+                    return null;
+                }
+            };
+        }
+    }
+    ;
+
+    private final String name;
+
+    private static final HashMap<String, AWSCredentialProviders> NAME2ENUM = new HashMap<>();
+    static {
+        for(AWSCredentialProviders p: values()){
+            NAME2ENUM.put(p.name, p);
+        }
+    }
+
+    AWSCredentialProviders(String name){
+        this.name = name;
+    }
+
+    public abstract AWSCredentialsProvider createProvider();
+
+    public static Optional<AWSCredentialProviders> fromName(String name){
+        return Optional.fromNullable(NAME2ENUM.get(name.toLowerCase()));
+    }
+
+
+}

--- a/embulk-input-s3/src/test/java/org/embulk/input/s3/TestAWSCredentialProviders.java
+++ b/embulk-input-s3/src/test/java/org/embulk/input/s3/TestAWSCredentialProviders.java
@@ -1,0 +1,35 @@
+package org.embulk.input.s3;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+
+import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
+import com.amazonaws.auth.InstanceProfileCredentialsProvider;
+import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.google.common.base.Optional;
+import org.junit.Test;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.*;
+
+public class TestAWSCredentialProviders {
+
+    @Test
+    public void testFromName(){
+        assertFromName("system", Optional.of(SystemPropertiesCredentialsProvider.class));
+        assertFromName("System", Optional.of(SystemPropertiesCredentialsProvider.class));
+        assertFromName("env", Optional.of(EnvironmentVariableCredentialsProvider.class));
+        assertFromName("instance", Optional.of(InstanceProfileCredentialsProvider.class));
+        assertFromName("profile", Optional.of(ProfileCredentialsProvider.class));
+        assertFromName("", Optional.absent());
+    }
+
+    private void assertFromName(final String name, Optional<Class<? extends AWSCredentialsProvider>> klass){
+        assertThat(AWSCredentialProviders.fromName(name).isPresent(), equalTo(klass.isPresent()));
+        if(klass.isPresent()){
+            assertThat(AWSCredentialProviders.fromName(name).get().createProvider().getClass(), equalTo(klass.get()));
+        }
+
+    }
+
+}

--- a/embulk-input-s3/src/test/java/org/embulk/input/s3/TestAbstractS3FileInputPlugin.java
+++ b/embulk-input-s3/src/test/java/org/embulk/input/s3/TestAbstractS3FileInputPlugin.java
@@ -1,0 +1,69 @@
+package org.embulk.input.s3;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
+import com.amazonaws.internal.StaticCredentialsProvider;
+import com.google.common.base.Optional;
+import org.embulk.config.ConfigException;
+import org.junit.Test;
+
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TestAbstractS3FileInputPlugin extends AbstractS3FileInputPlugin{
+
+    @Override
+    protected Class<? extends PluginTask> getTaskClass() {
+        return AbstractS3FileInputPlugin.PluginTask.class;
+    }
+
+    @Test
+    public void testGetCredentialsProviderWithProviderSpecified(){
+        PluginTask task = mock(PluginTask.class);
+        when(task.getAccessKeyId()).thenReturn(Optional.absent());
+        when(task.getSecretAccessKey()).thenReturn(Optional.absent());
+        when(task.getCredentialProvider()).thenReturn(Optional.of("env"));
+        assertThat(getCredentialsProvider(task) instanceof EnvironmentVariableCredentialsProvider, equalTo(true));
+    }
+
+    @Test
+    public void testGetCredentialsProviderWithProviderFallbackToDefault(){
+        PluginTask task = mock(PluginTask.class);
+        when(task.getAccessKeyId()).thenReturn(Optional.of("KEY"));
+        when(task.getSecretAccessKey()).thenReturn(Optional.of("KEY"));
+        when(task.getCredentialProvider()).thenReturn(Optional.absent());
+        assertThat(getCredentialsProvider(task) instanceof StaticCredentialsProvider, equalTo(true));
+    }
+
+    @Test
+    public void testGetCredentialsProviderWithProviderFallbackToDefaultByInvalidProviderName(){
+        PluginTask task = mock(PluginTask.class);
+        when(task.getAccessKeyId()).thenReturn(Optional.of("KEY"));
+        when(task.getSecretAccessKey()).thenReturn(Optional.of("KEY"));
+        when(task.getCredentialProvider()).thenReturn(Optional.of("static"));
+        assertThat(getCredentialsProvider(task) instanceof StaticCredentialsProvider, equalTo(true));
+    }
+
+    @Test(expected = ConfigException.class)
+    public void testGetCredentialsProviderThrowsNoAccessKeyWithoutProviderName(){
+        PluginTask task = mock(PluginTask.class);
+        when(task.getAccessKeyId()).thenReturn(Optional.absent());
+        when(task.getSecretAccessKey()).thenReturn(Optional.of("KEY"));
+        when(task.getCredentialProvider()).thenReturn(Optional.absent());
+        getCredentialsProvider(task);
+    }
+
+    @Test(expected = ConfigException.class)
+    public void testGetCredentialsProviderThrowsNoAccessKeyWithoutSecretKeyName(){
+        PluginTask task = mock(PluginTask.class);
+        when(task.getSecretAccessKey()).thenReturn(Optional.absent());
+        when(task.getAccessKeyId()).thenReturn(Optional.of("KEY"));
+        when(task.getCredentialProvider()).thenReturn(Optional.absent());
+        getCredentialsProvider(task);
+    }
+
+
+}


### PR DESCRIPTION
This commit introduces [CredentialProvider](http://docs.aws.amazon.com/en_us/AWSSdkDocsJava/latest//DeveloperGuide/credentials.html) Support.
With this feature we specify AWS credentials by various ways (e.g. from IAM role, environment variables or user profile)
