### PR TITLE
Enable logging of aws-sdk by including org.slf4j:jcl-over-slf4j

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ subprojects {
 
     configurations {
         provided
+        compile.exclude group: 'commons-logging', module: 'commons-logging'   // commons-logging api is provided by jcl-over-slf4j
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ subprojects {
     apply plugin: 'jacoco'
     apply plugin: 'com.github.jruby-gradle.base'
 
-
     repositories {
         mavenCentral()
         jcenter()
@@ -31,7 +30,7 @@ subprojects {
         compile  "org.embulk:embulk-core:0.7.0"
         provided "org.embulk:embulk-core:0.7.0"
         compile "com.amazonaws:aws-java-sdk-s3:1.9.22"
-
+        runtime "org.slf4j:jcl-over-slf4j:1.7.12"  // aws-sdk uses Apache Commons Logging and Embulk uses slf4j
         testCompile "junit:junit:4.+"
         testCompile "org.mockito:mockito-core:1.+"
         testCompile  "org.embulk:embulk-core:0.7.0:tests"


### PR DESCRIPTION
Embulk uses slf4j but aws-sdk uses Apache Commons Logging. To enable
logging of aws-sdk, include jcl-over-slf4j in classpath.