### PR TITLE
Bump aws java sdk version. Fixes #15.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+Release 0.2.4 - 2015-11-02
+
+* Bump AWS Java SDK version to fix date problem under Java 8u60.
+
 Release 0.2.3 - 2015-10-14
 
 * Enabled logging. Now we can get debug logs of AWS accesses using

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ import com.github.jrubygradle.JRubyExec
 
 allprojects {
     group = 'org.embulk.input.s3'
-    version = '0.2.3'
+    version = '0.2.4'
 }
 
 subprojects {
@@ -30,7 +30,7 @@ subprojects {
     dependencies {
         compile  "org.embulk:embulk-core:0.7.0"
         provided "org.embulk:embulk-core:0.7.0"
-        compile "com.amazonaws:aws-java-sdk-s3:1.9.22"
+        compile "com.amazonaws:aws-java-sdk-s3:1.10.29"
         runtime "org.slf4j:jcl-over-slf4j:1.7.12"  // aws-sdk uses Apache Commons Logging and Embulk uses slf4j
         testCompile "junit:junit:4.+"
         testCompile "org.mockito:mockito-core:1.+"


### PR DESCRIPTION
Plugin dependency (aws java sdk) is broken under JRE 1.8 update 60 and newer.