### PR TITLE
Add sourceCompatibility and targetCompatibility to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ subprojects {
         compile.exclude group: 'commons-logging', module: 'commons-logging'   // commons-logging api is provided by jcl-over-slf4j
     }
 
+    sourceCompatibility = 1.7
+    targetCompatibility = 1.7
+
     dependencies {
         compile  "org.embulk:embulk-core:0.7.9"
         provided "org.embulk:embulk-core:0.7.9"


### PR DESCRIPTION
It's better to declare same java version as Embulk itself.