### PR TITLE
path_match_pattern uses Matcher#find() instead of matches()

### DIFF
--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/FileList.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/FileList.java
@@ -129,7 +129,7 @@ public class FileList
                 return false;
             }
 
-            if (!pathMatchPattern.matcher(path).matches()) {
+            if (!pathMatchPattern.matcher(path).find()) {
                 return false;
             }
 

--- a/embulk-input-s3/src/test/java/org/embulk/input/s3/TestS3FileInputPlugin.java
+++ b/embulk-input-s3/src/test/java/org/embulk/input/s3/TestS3FileInputPlugin.java
@@ -119,11 +119,22 @@ public class TestS3FileInputPlugin
     public void usePathMatchPattern()
             throws Exception
     {
-        ConfigSource config = this.config.deepCopy().set("path_match_pattern", "/match/");
-        ConfigDiff configDiff = runner.transaction(config, new Control(runner, output));
+        { // match pattern
+            ConfigSource config = this.config.deepCopy().set("path_match_pattern", "/sample_01");
+            ConfigDiff configDiff = runner.transaction(config, new Control(runner, output));
 
-        assertNull(configDiff.get(String.class, "last_path"));
-        assertEquals(0, getRecords(config, output).size());
+            assertEquals(EMBULK_S3_TEST_PATH_PREFIX + "/sample_01.csv", configDiff.get(String.class, "last_path"));
+            assertRecords(config, output);
+        }
+
+        output = new MockPageOutput();
+        { // not match pattern
+            ConfigSource config = this.config.deepCopy().set("path_match_pattern", "/match/");
+            ConfigDiff configDiff = runner.transaction(config, new Control(runner, output));
+
+            assertNull(configDiff.get(String.class, "last_path"));
+            assertEquals(0, getRecords(config, output).size());
+        }
     }
 
     static class Control


### PR DESCRIPTION
Matcher#find() matches the spec of path_match_pattern instead.
https://docs.oracle.com/javase/7/docs/api/java/util/regex/Matcher.html