### PR TITLE
Make ClientConfiguration Configurable!

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,60 @@
 
     - **session_token**: session token (string, required)
 
+- **client_config**: configure S3 client config (optional)
+
+  - **protocol**: (enum, `HTTP` or `HTTPS`, optional)
+
+  - **max_connections**: (int, optional)
+
+  - **user_agent** (string, optional)
+
+  - **local_address**: name of a hostname (string, optional)
+
+  - **proxy_host**: name of a hostname (string, optional)
+
+  - **proxy_port**: (int, optional)
+
+  - **proxy_username**: (string, optional)
+
+  - **proxy_password**: (string, optional)
+
+  - **proxy_domain**: (string, optional)
+
+  - **proxy_workstation**: (string, optional)
+
+  - **max_error_retry**: (int, optional)
+
+  - **socket_timeout**: (int, optional)
+
+  - **connection_timeout**: (int, optional)
+
+  - **request_timeout**: (int, optional)
+
+  - **use_reaper**: (boolean, optional)
+
+  - **use_gzip**: (boolean, optional)
+
+  - **signer_override**: (string, optional)
+
+  - **preemptive_basic_proxy_auth**: (boolean, optional)
+
+  - **connection_ttl**: (long, optional)
+
+  - **connection_max_idle_millis**: (long, optional)
+
+  - **use_tcp_keep_alive**: (boolean, optional)
+
+  - **response_metadata_cache_size**: (int, optional)
+
+  - **use_expect_continue**: (boolean, optional)
+
+  - **secure_random**: (optional)
+
+    - **algorithm**: (string, required)
+
+    - **provider**: (string, optional)
+
 * **path_match_pattern**: regexp to match file paths. If a file path doesn't match with this pattern, the file will be skipped (regexp string, optional)
 
 * **total_file_count_limit**: maximum number of files to read (integer, optional)

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
@@ -1,19 +1,15 @@
 package org.embulk.input.s3;
 
 import java.util.List;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.io.InputStream;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import org.slf4j.Logger;
-import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ListObjectsRequest;
@@ -23,7 +19,6 @@ import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.AmazonServiceException;
-import com.amazonaws.Protocol;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigInject;
 import org.embulk.config.ConfigDefault;
@@ -65,7 +60,9 @@ public abstract class AbstractS3FileInputPlugin
         @ConfigDefault("null")
         public Optional<String> getAccessKeyId();
 
-        // TODO timeout, ssl, etc
+        @Config("client_config")
+        @ConfigDefault("{}")
+        public ClientConfigurationConfigurable.Task getClientConfigurationConfigurableTask();
 
         public FileList getFiles();
         public void setFiles(FileList files);
@@ -129,14 +126,8 @@ public abstract class AbstractS3FileInputPlugin
 
     protected ClientConfiguration getClientConfiguration(PluginTask task)
     {
-        ClientConfiguration clientConfig = new ClientConfiguration();
-
-        //clientConfig.setProtocol(Protocol.HTTP);
-        clientConfig.setMaxConnections(50); // SDK default: 50
-        clientConfig.setMaxErrorRetry(3); // SDK default: 3
-        clientConfig.setSocketTimeout(8*60*1000); // SDK default: 50*1000
-
-        return clientConfig;
+        ClientConfigurationConfigurable.Task configurableTask = task.getClientConfigurationConfigurableTask();
+        return ClientConfigurationConfigurable.getClientConfiguration(configurableTask);
     }
 
     private FileList listFiles(PluginTask task)

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/ClientConfigurationConfigurable.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/ClientConfigurationConfigurable.java
@@ -1,0 +1,421 @@
+package org.embulk.input.s3;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.Protocol;
+import com.google.common.base.Optional;
+import org.embulk.config.Config;
+import org.embulk.config.ConfigDefault;
+import org.embulk.config.ConfigException;
+import org.embulk.config.Task;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.SecureRandom;
+
+/**
+ * Created by takahiro.nakayama on 3/25/16.
+ * This class is utility class for ClientConfiguration
+ */
+public abstract class ClientConfigurationConfigurable
+{
+    public interface Task
+        extends org.embulk.config.Task
+    {
+        @Config("protocol")
+        @ConfigDefault("null")
+        Optional<Protocol> getProtocol();
+
+        @Config("max_connections")
+        @ConfigDefault("null") // default: 50
+        Optional<Integer> getMaxConnections();
+
+        @Config("user_agent")
+        @ConfigDefault("null")
+        Optional<String> getUserAgent();
+
+        @Config("local_address")
+        @ConfigDefault("null")
+        Optional<String> getLocalAddress();
+
+        @Config("proxy_host")
+        @ConfigDefault("null")
+        Optional<String> getProxyHost();
+
+        @Config("proxy_port")
+        @ConfigDefault("null")
+        Optional<Integer> getProxyPort();
+
+        @Config("proxy_username")
+        @ConfigDefault("null")
+        Optional<String> getProxyUsername();
+
+        @Config("proxy_password")
+        @ConfigDefault("null")
+        Optional<String> getProxyPassword();
+
+        @Config("proxy_domain")
+        @ConfigDefault("null")
+        Optional<String> getProxyDomain();
+
+        @Config("proxy_workstation")
+        @ConfigDefault("null")
+        Optional<String> getProxyWorkstation();
+
+        // NOTE: RetryPolicy is a interface
+        // @Config("retry_policy")
+        // @ConfigDefault("null")
+        // Optional<RetryPolicy> getRetryPolicy();
+
+        @Config("max_error_retry")
+        @ConfigDefault("null") // default: 3
+        Optional<Integer> getMaxErrorRetry();
+
+        @Config("socket_timeout")
+        @ConfigDefault("null") // default: 8*60*1000
+        Optional<Integer> getSocketTimeout();
+
+        @Config("connection_timeout")
+        @ConfigDefault("null")
+        Optional<Integer> getConnectionTimeout();
+
+        @Config("request_timeout")
+        @ConfigDefault("null")
+        Optional<Integer> getRequestTimeout();
+
+        // NOTE: Can use `client_execution_timeout` from v1.10.65
+        // @Config("client_execution_timeout")
+        // @ConfigDefault("null")
+        // Optional<Integer> getClientExecutionTimeout();
+
+        @Config("use_reaper")
+        @ConfigDefault("null")
+        Optional<Boolean> getUseReaper();
+
+        // NOTE: Can use `use_throttle_retries` from v1.10.65
+        // @Config("use_throttle_retries")
+        // @ConfigDefault("null")
+        // Optional<Boolean> getUseThrottleRetries();
+
+        @Config("use_gzip")
+        @ConfigDefault("null")
+        Optional<Boolean> getUseGzip();
+
+        @Config("socket_send_buffer_size_hints") // used by SocketBufferSizeHints
+        @ConfigDefault("null")
+        Optional<Integer> getSocketSendBufferSizeHint();
+
+        @Config("socket_receive_buffer_size_hints") // used by SocketBufferSizeHints
+        @ConfigDefault("null")
+        Optional<Integer> getSocketReceiveBufferSizeHints();
+
+        @Config("signer_override")
+        @ConfigDefault("null")
+        Optional<String> getSignerOverride();
+
+        @Config("preemptive_basic_proxy_auth")
+        @ConfigDefault("null")
+        Optional<Boolean> getPreemptiveBasicProxyAuth();
+
+        @Config("connection_ttl")
+        @ConfigDefault("null")
+        Optional<Long> getConnectionTTL();
+
+        @Config("connection_max_idle_millis")
+        @ConfigDefault("null")
+        Optional<Long> getConnectionMaxIdleMillis();
+
+        @Config("use_tcp_keep_alive")
+        @ConfigDefault("null")
+        Optional<Boolean> getUseTcpKeepAlive();
+
+        // NOTE: DnsResolver is a interface
+        // @Config("dns_resolver")
+        // @ConfigDefault("null")
+        // Optional<DnsResolver> getDnsResolver();
+
+        @Config("response_metadata_cache_size")
+        @ConfigDefault("null")
+        Optional<Integer> getResponseMetadataCacheSize();
+
+        @Config("secure_random")
+        @ConfigDefault("null")
+        Optional<SecureRandomTask> getSecureRandom();
+
+        @Config("use_expect_continue")
+        @ConfigDefault("null")
+        Optional<Boolean> getUseExpectContinue();
+    }
+
+    public interface SecureRandomTask
+        extends org.embulk.config.Task
+    {
+        @Config("algorithm")
+        String getAlgorithm();
+
+        @Config("provider")
+        @ConfigDefault("null")
+        Optional<String> getProvider();
+    }
+
+    protected ClientConfigurationConfigurable()
+    {
+    }
+
+    // For backward compatibility
+    public static final int DEFAULT_MAX_CONNECTIONS = 50; // SDK default: 50
+    public static final int DEFAULT_MAX_ERROR_RETRY = 3;  // SDK default: 3
+    public static final int DEFAULT_SOCKET_TIMEOUT = 8*60*1000; // SDK default: 50*1000
+
+    public static ClientConfiguration getClientConfiguration(Task task)
+    {
+        ClientConfiguration clientConfiguration = new ClientConfiguration();
+
+        setProtocolOrDoNothing(clientConfiguration, task.getProtocol());
+        setMaxConnectionsOrDoNothing(clientConfiguration, task.getMaxConnections());
+        setUserAgentOrDoNothing(clientConfiguration, task.getUserAgent());
+
+        setLocalAddressOrDoNothing(clientConfiguration, task.getLocalAddress());
+        setProxyHostOrDoNothing(clientConfiguration, task.getProxyHost());
+        setProxyPortOrDoNothing(clientConfiguration, task.getProxyPort());
+
+        setProxyUsernameOrDoNothing(clientConfiguration, task.getProxyUsername());
+        setProxyPasswordOrDoNothing(clientConfiguration, task.getProxyPassword());
+        setProxyDomainOrDoNothing(clientConfiguration, task.getProxyDomain());
+
+        setProxyWorkstationOrDoNothing(clientConfiguration, task.getProxyWorkstation());
+        setMaxErrorRetryOrDoNothing(clientConfiguration, task.getMaxErrorRetry());
+        setSocketTimeoutOrDoNothing(clientConfiguration, task.getSocketTimeout());
+
+        setConnectionTimeoutOrDoNothing(clientConfiguration, task.getConnectionTimeout());
+        setRequestTimeoutOrDoNothing(clientConfiguration, task.getRequestTimeout());
+        setUseReaperOrDoNothing(clientConfiguration, task.getUseReaper());
+
+        setUseGzipOrDoNothing(clientConfiguration, task.getUseGzip());
+        setSocketBufferSizeHintsOrDoNothing(clientConfiguration, task.getSocketSendBufferSizeHint(),
+                task.getSocketReceiveBufferSizeHints());
+
+        setSignerOverrideOrDoNothing(clientConfiguration, task.getSignerOverride());
+        setPreemptiveBasicProxyAuthOrDoNothing(clientConfiguration, task.getPreemptiveBasicProxyAuth());
+        setConnectionTTLOrDoNothing(clientConfiguration, task.getConnectionTTL());
+
+        setConnectionMaxIdleMillisOrDoNothing(clientConfiguration, task.getConnectionMaxIdleMillis());
+        setUseTcpKeepAliveOrDoNothing(clientConfiguration, task.getUseTcpKeepAlive());
+        setResponseMetadataCacheSizeOrDoNothing(clientConfiguration, task.getResponseMetadataCacheSize());
+
+        setSecureRandomOrDoNothing(clientConfiguration, task.getSecureRandom());
+        setUseExpectContinueOrDoNothing(clientConfiguration, task.getUseExpectContinue());
+
+        setRetryPolicy(clientConfiguration);
+        setDnsResolver(clientConfiguration);
+
+        return clientConfiguration;
+    }
+
+    protected static void setProtocolOrDoNothing(ClientConfiguration clientConfiguration, Optional<Protocol> protocol)
+    {
+        if (protocol.isPresent()) {
+            clientConfiguration.setProtocol(protocol.get());
+        }
+    }
+
+    protected static void setMaxConnectionsOrDoNothing(ClientConfiguration clientConfiguration, Optional<Integer> maxConnections)
+    {
+        clientConfiguration.setMaxConnections(maxConnections.or(DEFAULT_MAX_CONNECTIONS));
+    }
+
+    protected static void setUserAgentOrDoNothing(ClientConfiguration clientConfiguration, Optional<String> userAgent)
+    {
+        if (userAgent.isPresent()) {
+            clientConfiguration.setUserAgent(userAgent.get());
+        }
+    }
+
+    protected static void setLocalAddressOrDoNothing(ClientConfiguration clientConfiguration, Optional<String> localAddress)
+    {
+        if (localAddress.isPresent()) {
+            InetAddress inetAddress = getInetAddress(localAddress.get());
+            clientConfiguration.setLocalAddress(inetAddress);
+        }
+    }
+
+    protected static void setProxyHostOrDoNothing(ClientConfiguration clientConfiguration, Optional<String> proxyHost)
+    {
+        if (proxyHost.isPresent()) {
+            clientConfiguration.setProxyHost(proxyHost.get());
+        }
+    }
+
+    protected static void setProxyPortOrDoNothing(ClientConfiguration clientConfiguration, Optional<Integer> proxyPort)
+    {
+        if (proxyPort.isPresent()) {
+            clientConfiguration.setProxyPort(proxyPort.get());
+        }
+    }
+
+    protected static void setProxyUsernameOrDoNothing(ClientConfiguration clientConfiguration, Optional<String> proxyUsername)
+    {
+        if (proxyUsername.isPresent()) {
+            clientConfiguration.setProxyUsername(proxyUsername.get());
+        }
+    }
+
+    protected static void setProxyPasswordOrDoNothing(ClientConfiguration clientConfiguration, Optional<String> proxyPassword)
+    {
+        if (proxyPassword.isPresent()) {
+            clientConfiguration.setProxyPassword(proxyPassword.get());
+        }
+    }
+
+    protected static void setProxyDomainOrDoNothing(ClientConfiguration clientConfiguration, Optional<String> proxyDomain)
+    {
+        if (proxyDomain.isPresent()) {
+            clientConfiguration.setProxyDomain(proxyDomain.get());
+        }
+    }
+
+    protected static void setProxyWorkstationOrDoNothing(ClientConfiguration clientConfiguration, Optional<String> proxyWorkstation)
+    {
+        if (proxyWorkstation.isPresent()) {
+            clientConfiguration.setProxyWorkstation(proxyWorkstation.get());
+        }
+    }
+
+    protected static void setMaxErrorRetryOrDoNothing(ClientConfiguration clientConfiguration, Optional<Integer> maxErrorRetry)
+    {
+        clientConfiguration.setMaxErrorRetry(maxErrorRetry.or(DEFAULT_MAX_ERROR_RETRY));
+    }
+
+    protected static void setSocketTimeoutOrDoNothing(ClientConfiguration clientConfiguration, Optional<Integer> socketTimeout)
+    {
+        clientConfiguration.setSocketTimeout(socketTimeout.or(DEFAULT_SOCKET_TIMEOUT));
+    }
+
+    protected static void setConnectionTimeoutOrDoNothing(ClientConfiguration clientConfiguration, Optional<Integer> connectionTimeout)
+    {
+        if (connectionTimeout.isPresent()) {
+            clientConfiguration.setConnectionTimeout(connectionTimeout.get());
+        }
+    }
+
+    protected static void setRequestTimeoutOrDoNothing(ClientConfiguration clientConfiguration, Optional<Integer> requestTimeout)
+    {
+        if (requestTimeout.isPresent()) {
+            clientConfiguration.setRequestTimeout(requestTimeout.get());
+        }
+    }
+
+    protected static void setUseReaperOrDoNothing(ClientConfiguration clientConfiguration, Optional<Boolean> useReaper)
+    {
+        if (useReaper.isPresent()) {
+            clientConfiguration.setUseReaper(useReaper.get());
+        }
+    }
+
+    protected static void setUseGzipOrDoNothing(ClientConfiguration clientConfiguration, Optional<Boolean> useGzip)
+    {
+        if (useGzip.isPresent()) {
+            clientConfiguration.setUseGzip(useGzip.get());
+        }
+    }
+
+    protected static void setSocketBufferSizeHintsOrDoNothing(ClientConfiguration clientConfiguration,
+            Optional<Integer> socketSendBufferSizeHint, Optional<Integer> socketReceiveBufferSizeHint)
+    {
+        if (socketSendBufferSizeHint.isPresent() && socketReceiveBufferSizeHint.isPresent()) {
+            clientConfiguration.setSocketBufferSizeHints(socketSendBufferSizeHint.get(), socketReceiveBufferSizeHint.get());
+        }
+    }
+
+    protected static void setSignerOverrideOrDoNothing(ClientConfiguration clientConfiguration, Optional<String> value)
+    {
+        if (value.isPresent()) {
+            clientConfiguration.setSignerOverride(value.get());
+        }
+    }
+
+    protected static void setPreemptiveBasicProxyAuthOrDoNothing(ClientConfiguration clientConfiguration, Optional<Boolean> preemptiveBasicProxyAuth)
+    {
+        if (preemptiveBasicProxyAuth.isPresent()) {
+            clientConfiguration.setPreemptiveBasicProxyAuth(preemptiveBasicProxyAuth.get());
+        }
+    }
+
+    protected static void setConnectionTTLOrDoNothing(ClientConfiguration clientConfiguration, Optional<Long> connectionTTL)
+    {
+        if (connectionTTL.isPresent()) {
+            clientConfiguration.setConnectionTTL(connectionTTL.get());
+        }
+    }
+
+    protected static void setConnectionMaxIdleMillisOrDoNothing(ClientConfiguration clientConfiguration, Optional<Long> connectionMaxIdleMillis)
+    {
+        if (connectionMaxIdleMillis.isPresent()) {
+            clientConfiguration.setConnectionMaxIdleMillis(connectionMaxIdleMillis.get());
+        }
+    }
+
+    protected static void setUseTcpKeepAliveOrDoNothing(ClientConfiguration clientConfiguration, Optional<Boolean> useTcpKeepAlive)
+    {
+        if (useTcpKeepAlive.isPresent()) {
+            clientConfiguration.setUseTcpKeepAlive(useTcpKeepAlive.get());
+        }
+    }
+
+    protected static void setResponseMetadataCacheSizeOrDoNothing(ClientConfiguration clientConfiguration, Optional<Integer> responseMetadataCacheSize)
+    {
+        if (responseMetadataCacheSize.isPresent()) {
+            clientConfiguration.setResponseMetadataCacheSize(responseMetadataCacheSize.get());
+        }
+    }
+
+    protected static void setSecureRandomOrDoNothing(ClientConfiguration clientConfiguration, Optional<SecureRandomTask> secureRandomTask)
+    {
+        if (secureRandomTask.isPresent()) {
+            SecureRandom secureRandom = getSecureRandom(secureRandomTask.get());
+            clientConfiguration.setSecureRandom(secureRandom);
+        }
+    }
+
+    protected static void setUseExpectContinueOrDoNothing(ClientConfiguration clientConfiguration, Optional<Boolean> useExpectContinue)
+    {
+        if (useExpectContinue.isPresent()) {
+            clientConfiguration.setUseExpectContinue(useExpectContinue.get());
+        }
+    }
+
+    protected static void setRetryPolicy(ClientConfiguration clientConfiguration)
+    {
+    }
+
+    protected static void setDnsResolver(ClientConfiguration clientConfiguration)
+    {
+    }
+
+
+    private static InetAddress getInetAddress(String host)
+    {
+        try {
+            return InetAddress.getByName(host);
+        }
+        catch (UnknownHostException e) {
+            throw new ConfigException(e);
+        }
+    }
+
+    private static SecureRandom getSecureRandom(SecureRandomTask secureRandomTask)
+    {
+        try {
+            if (secureRandomTask.getProvider().isPresent()) {
+                return SecureRandom.getInstance(secureRandomTask.getAlgorithm(), secureRandomTask.getProvider().get());
+            }
+            else {
+                return SecureRandom.getInstance(secureRandomTask.getAlgorithm());
+            }
+        }
+        catch (NoSuchAlgorithmException | NoSuchProviderException e) {
+            throw new ConfigException(e);
+        }
+    }
+}

--- a/embulk-input-s3/src/test/java/org/embulk/input/s3/TestClientConfigurationConfigurable.java
+++ b/embulk-input-s3/src/test/java/org/embulk/input/s3/TestClientConfigurationConfigurable.java
@@ -1,0 +1,145 @@
+package org.embulk.input.s3;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.Protocol;
+import org.embulk.EmbulkTestRuntime;
+import org.embulk.config.ConfigException;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.TaskReport;
+import org.embulk.config.TaskSource;
+import org.embulk.spi.Exec;
+import org.embulk.spi.FileInputRunner;
+import org.embulk.spi.InputPlugin;
+import org.embulk.spi.Schema;
+import org.embulk.spi.TestPageBuilderReader;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.List;
+
+import static org.embulk.input.s3.TestS3FileInputPlugin.parserConfig;
+import static org.embulk.input.s3.TestS3FileInputPlugin.schemaConfig;
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeNotNull;
+
+/**
+ * Created by takahiro.nakayama on 3/30/16.
+ */
+public class TestClientConfigurationConfigurable
+{
+    private static String EMBULK_S3_TEST_BUCKET;
+    private static String EMBULK_S3_TEST_ACCESS_KEY_ID;
+    private static String EMBULK_S3_TEST_SECRET_ACCESS_KEY;
+    private static final String EMBULK_S3_TEST_PATH_PREFIX = "embulk_input_s3_test";
+
+    /*
+     * This test case requires environment variables:
+     *   EMBULK_S3_TEST_BUCKET
+     *   EMBULK_S3_TEST_ACCESS_KEY_ID
+     *   EMBULK_S3_TEST_SECRET_ACCESS_KEY
+     * If the variables not set, the test case is skipped.
+     */
+    @BeforeClass
+    public static void initializeConstantVariables()
+    {
+        EMBULK_S3_TEST_BUCKET = System.getenv("EMBULK_S3_TEST_BUCKET");
+        EMBULK_S3_TEST_ACCESS_KEY_ID = System.getenv("EMBULK_S3_TEST_ACCESS_KEY_ID");
+        EMBULK_S3_TEST_SECRET_ACCESS_KEY = System.getenv("EMBULK_S3_TEST_SECRET_ACCESS_KEY");
+        assumeNotNull(EMBULK_S3_TEST_BUCKET, EMBULK_S3_TEST_ACCESS_KEY_ID, EMBULK_S3_TEST_SECRET_ACCESS_KEY);
+    }
+
+    @Rule
+    public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
+
+    private S3FileInputPlugin plugin;
+    private ConfigSource config;
+    private FileInputRunner runner;
+    private TestPageBuilderReader.MockPageOutput output;
+
+    @Before
+    public void createResources()
+    {
+        plugin = new S3FileInputPlugin();
+        config = runtime.getExec().newConfigSource()
+                .set("type", "s3")
+                .set("bucket", EMBULK_S3_TEST_BUCKET)
+                .set("path_prefix", EMBULK_S3_TEST_PATH_PREFIX)
+                .set("parser", parserConfig(schemaConfig()));
+        runner = new FileInputRunner(runtime.getInstance(S3FileInputPlugin.class));
+        output = new TestPageBuilderReader.MockPageOutput();
+    }
+
+    @Test
+    public void setOneParam()
+    {
+        config.setNested("client_config", Exec.newConfigSource()
+        .set("protocol", "HTTP")
+        .set("user_agent", "test_embulk_input_s3"));
+
+        ClientConfiguration clientConfiguration = getClientConfiguration();
+
+        assertEquals(Protocol.HTTP, clientConfiguration.getProtocol());
+        assertEquals("test_embulk_input_s3", clientConfiguration.getUserAgent());
+    }
+
+    @Test
+    public void setTwoParam()
+    {
+        config.setNested("client_config", Exec.newConfigSource()
+        .set("socket_send_buffer_size_hints", 4)
+        .set("socket_receive_buffer_size_hints", 8));
+
+        ClientConfiguration clientConfiguration = getClientConfiguration();
+
+        int[] socketBufferSizeHints = clientConfiguration.getSocketBufferSizeHints();
+        assertEquals(4, socketBufferSizeHints[0]);
+        assertEquals(8, socketBufferSizeHints[1]);
+    }
+
+    @Test
+    public void defaultValue()
+    {
+        ClientConfiguration clientConfiguration = getClientConfiguration();
+
+        assertEquals(3, clientConfiguration.getMaxErrorRetry());
+        assertEquals(50, clientConfiguration.getMaxConnections());
+        assertEquals(8*60*1000, clientConfiguration.getSocketTimeout());
+    }
+
+    @Test
+    public void secureRandom()
+            throws NoSuchAlgorithmException
+    {
+        config.setNested("client_config", Exec.newConfigSource()
+                .setNested("secure_random", Exec.newConfigSource()
+                        .set("algorithm", "SHA1PRNG")
+                )
+        );
+
+        ClientConfiguration clientConfiguration = getClientConfiguration();
+
+        assertEquals(SecureRandom.getInstance("SHA1PRNG").getAlgorithm(), clientConfiguration.getSecureRandom().getAlgorithm());
+    }
+
+    @Test(expected = ConfigException.class)
+    public void secureRandomNoSuchAlgorithmException()
+    {
+        config.setNested("client_config", Exec.newConfigSource()
+                .setNested("secure_random", Exec.newConfigSource()
+                        .set("algorithm", "FOOOOOOO")
+                )
+        );
+
+        ClientConfiguration clientConfiguration = getClientConfiguration();
+    }
+
+    private ClientConfiguration getClientConfiguration()
+    {
+        S3FileInputPlugin.S3PluginTask task = config.loadConfig(S3FileInputPlugin.S3PluginTask.class);
+        return plugin.getClientConfiguration(task);
+    }
+}

--- a/embulk-input-s3/src/test/java/org/embulk/input/s3/TestClientConfigurationConfigurable.java
+++ b/embulk-input-s3/src/test/java/org/embulk/input/s3/TestClientConfigurationConfigurable.java
@@ -5,60 +5,28 @@ import com.amazonaws.Protocol;
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigSource;
-import org.embulk.config.TaskReport;
-import org.embulk.config.TaskSource;
 import org.embulk.spi.Exec;
-import org.embulk.spi.FileInputRunner;
-import org.embulk.spi.InputPlugin;
-import org.embulk.spi.Schema;
-import org.embulk.spi.TestPageBuilderReader;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.util.List;
 
 import static org.embulk.input.s3.TestS3FileInputPlugin.parserConfig;
 import static org.embulk.input.s3.TestS3FileInputPlugin.schemaConfig;
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeNotNull;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Created by takahiro.nakayama on 3/30/16.
  */
 public class TestClientConfigurationConfigurable
 {
-    private static String EMBULK_S3_TEST_BUCKET;
-    private static String EMBULK_S3_TEST_ACCESS_KEY_ID;
-    private static String EMBULK_S3_TEST_SECRET_ACCESS_KEY;
-    private static final String EMBULK_S3_TEST_PATH_PREFIX = "embulk_input_s3_test";
-
-    /*
-     * This test case requires environment variables:
-     *   EMBULK_S3_TEST_BUCKET
-     *   EMBULK_S3_TEST_ACCESS_KEY_ID
-     *   EMBULK_S3_TEST_SECRET_ACCESS_KEY
-     * If the variables not set, the test case is skipped.
-     */
-    @BeforeClass
-    public static void initializeConstantVariables()
-    {
-        EMBULK_S3_TEST_BUCKET = System.getenv("EMBULK_S3_TEST_BUCKET");
-        EMBULK_S3_TEST_ACCESS_KEY_ID = System.getenv("EMBULK_S3_TEST_ACCESS_KEY_ID");
-        EMBULK_S3_TEST_SECRET_ACCESS_KEY = System.getenv("EMBULK_S3_TEST_SECRET_ACCESS_KEY");
-        assumeNotNull(EMBULK_S3_TEST_BUCKET, EMBULK_S3_TEST_ACCESS_KEY_ID, EMBULK_S3_TEST_SECRET_ACCESS_KEY);
-    }
-
     @Rule
     public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
 
     private S3FileInputPlugin plugin;
     private ConfigSource config;
-    private FileInputRunner runner;
-    private TestPageBuilderReader.MockPageOutput output;
 
     @Before
     public void createResources()
@@ -66,11 +34,9 @@ public class TestClientConfigurationConfigurable
         plugin = new S3FileInputPlugin();
         config = runtime.getExec().newConfigSource()
                 .set("type", "s3")
-                .set("bucket", EMBULK_S3_TEST_BUCKET)
-                .set("path_prefix", EMBULK_S3_TEST_PATH_PREFIX)
+                .set("bucket", "dummy")
+                .set("path_prefix", "dummy")
                 .set("parser", parserConfig(schemaConfig()));
-        runner = new FileInputRunner(runtime.getInstance(S3FileInputPlugin.class));
-        output = new TestPageBuilderReader.MockPageOutput();
     }
 
     @Test


### PR DESCRIPTION
Hi @frsyuki @muga 

I wrote `ClientConfigurationConfiguable` class, which make it possible to be configured `ClientConfiguration` by users' config.yml.
(Because I want to change the `maxErrorRetry` parameter.)

So, how do you think?

NOTE: `RetryPolicy` and `DnsResolver` is interface, so they cannot be configured by the yaml.