### PR TITLE
Support incremental flag

### DIFF
--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
@@ -65,6 +65,10 @@ public abstract class AbstractS3FileInputPlugin
         @ConfigDefault("null")
         public Optional<String> getAccessKeyId();
 
+        @Config("incremental")
+        @ConfigDefault("true")
+        public boolean getIncremental();
+
         // TODO timeout, ssl, etc
 
         public FileList getFiles();
@@ -104,7 +108,9 @@ public abstract class AbstractS3FileInputPlugin
         ConfigDiff configDiff = Exec.newConfigDiff();
 
         // last_path
-        configDiff.set("last_path", task.getFiles().getLastPath(task.getLastPath()));
+        if (task.getIncremental()) {
+            configDiff.set("last_path", task.getFiles().getLastPath(task.getLastPath()));
+        }
 
         return configDiff;
     }

--- a/embulk-input-s3/src/test/java/org/embulk/input/s3/TestS3FileInputPlugin.java
+++ b/embulk-input-s3/src/test/java/org/embulk/input/s3/TestS3FileInputPlugin.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assume.assumeNotNull;
 
@@ -89,6 +90,15 @@ public class TestS3FileInputPlugin
 
         assertEquals(EMBULK_S3_TEST_PATH_PREFIX + "/sample_01.csv", configDiff.get(String.class, "last_path"));
         assertEquals(0, getRecords(config, output).size());
+    }
+
+    @Test
+    public void useIncremental()
+    {
+        ConfigSource config = this.config.deepCopy().set("incremental", false);
+        ConfigDiff configDiff = runner.transaction(config, new Control(runner, output));
+
+        assertFalse(configDiff.has("last_path"));
     }
 
     @Test


### PR DESCRIPTION
We have a system that automates incremental data loading. But some use cases don't need incremental data loading. Instead, they load the entire data every time and replaces the data in the destination table every time. This flag controls the behavior.