### PR TITLE
Use `DefaultAWSCredentialsProviderChain` to let aws-java-sdk to lookup available credentials automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@
 
     - **session_token**: session token (string, required)
 
+  - "default": uses AWS SDK's default strategy to look up available credentials from runtime environment. This method behaves like the combination of the following methods.
+
+    1. "env"
+    1. "properties"
+    1. "profile"
+    1. "instance"
+
+
 * **path_match_pattern**: regexp to match file paths. If a file path doesn't match with this pattern, the file will be skipped (regexp string, optional)
 
 * **total_file_count_limit**: maximum number of files to read (integer, optional)

--- a/embulk-util-aws-credentials/src/main/java/org/embulk/util/aws/credentials/AwsCredentials.java
+++ b/embulk-util-aws-credentials/src/main/java/org/embulk/util/aws/credentials/AwsCredentials.java
@@ -163,6 +163,11 @@ public abstract class AwsCredentials
 
         case "default":
             {
+                reject(task.getAccessKeyId(), accessKeyIdOption);
+                reject(task.getSecretAccessKey(), secretAccessKeyOption);
+                reject(task.getSessionToken(), sessionTokenOption);
+                reject(task.getProfileFile(), profileFileOption);
+                reject(task.getProfileName(), profileNameOption);
                 return new DefaultAWSCredentialsProviderChain();
             }
 

--- a/embulk-util-aws-credentials/src/main/java/org/embulk/util/aws/credentials/AwsCredentials.java
+++ b/embulk-util-aws-credentials/src/main/java/org/embulk/util/aws/credentials/AwsCredentials.java
@@ -8,6 +8,7 @@ import com.amazonaws.auth.AWSSessionCredentialsProvider;
 import com.amazonaws.auth.AnonymousAWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.BasicSessionCredentials;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
@@ -160,8 +161,13 @@ public abstract class AwsCredentials
                 };
             }
 
+        case "default":
+            {
+                return new DefaultAWSCredentialsProviderChain();
+            }
+
         default:
-            throw new ConfigException(String.format("Unknown auth_method '%s'. Supported methods are basic, instance, profile, properties, anonymous, and session.",
+            throw new ConfigException(String.format("Unknown auth_method '%s'. Supported methods are basic, instance, profile, properties, anonymous, session and default.",
                         task.getAuthMethod()));
         }
     }


### PR DESCRIPTION
AWS SDK has default credentials provider to look up available credentials from runtime environment. With adding an `auth_method`, we don't need to specify custom methods like `env`, `properties`, `instance` and `profile` for most cases.

http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html