### PR TITLE
Add HttpProxy option

### DIFF
--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
@@ -67,6 +67,11 @@ public abstract class AbstractS3FileInputPlugin
         @ConfigDefault("null")
         public Optional<String> getAccessKeyId();
 
+        @Config("http_proxy")
+        @ConfigDefault("null")
+        public Optional<HttpProxy> getHttpProxy();
+        public void setHttpProxy(Optional<HttpProxy> httpProxy);
+
         @Config("incremental")
         @ConfigDefault("true")
         public boolean getIncremental();
@@ -86,6 +91,9 @@ public abstract class AbstractS3FileInputPlugin
     public ConfigDiff transaction(ConfigSource config, FileInputPlugin.Control control)
     {
         PluginTask task = config.loadConfig(getTaskClass());
+
+        // configure http proxy
+        task.setHttpProxy(setupHttpProxy(task));
 
         // list files recursively
         task.setFiles(listFiles(task));
@@ -144,7 +152,44 @@ public abstract class AbstractS3FileInputPlugin
         clientConfig.setMaxErrorRetry(3); // SDK default: 3
         clientConfig.setSocketTimeout(8*60*1000); // SDK default: 50*1000
 
+        // set http proxy
+        if (task.getHttpProxy().isPresent()) {
+            setHttpProxy(clientConfig, task.getHttpProxy().get());
+        }
+
         return clientConfig;
+    }
+
+    private Optional<HttpProxy> setupHttpProxy(PluginTask task)
+    {
+        // If users configure http proxy in in: section, the settings are used. If http proxy settings
+        // don't exist in the config, it searches and extracts from environment variables: "HTTPS_PROXY",
+        // "https_proxy", "HTTP_PROXY", "http_proxy".
+        return task.getHttpProxy().or(HttpProxy.getHttpProxyFromEnv());
+    }
+
+    private void setHttpProxy(ClientConfiguration clientConfig, HttpProxy httpProxy)
+    {
+        // host
+        clientConfig.setProxyHost(httpProxy.getHost());
+
+        // port
+        if (httpProxy.getPort().isPresent()) {
+            clientConfig.setProxyPort(httpProxy.getPort().get());
+        }
+
+        // useSsl
+        clientConfig.setProtocol(httpProxy.useSsl() ? Protocol.HTTPS : Protocol.HTTP);
+
+        // user
+        if (httpProxy.getUser().isPresent()) {
+            clientConfig.setProxyUsername(httpProxy.getUser().get());
+        }
+
+        // password
+        if (httpProxy.getPassword().isPresent()) {
+            clientConfig.setProxyPassword(httpProxy.getPassword().get());
+        }
     }
 
     private FileList listFiles(PluginTask task)

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
@@ -167,8 +167,8 @@ public abstract class AbstractS3FileInputPlugin
             clientConfig.setProxyPort(httpProxy.getPort().get());
         }
 
-        // useSsl
-        clientConfig.setProtocol(httpProxy.useSsl() ? Protocol.HTTPS : Protocol.HTTP);
+        // useHttps
+        clientConfig.setProtocol(httpProxy.useHttps() ? Protocol.HTTPS : Protocol.HTTP);
 
         // user
         if (httpProxy.getUser().isPresent()) {

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
@@ -92,9 +92,6 @@ public abstract class AbstractS3FileInputPlugin
     {
         PluginTask task = config.loadConfig(getTaskClass());
 
-        // configure http proxy
-        task.setHttpProxy(createHttpProxyWithDefault(task));
-
         // list files recursively
         task.setFiles(listFiles(task));
 
@@ -158,14 +155,6 @@ public abstract class AbstractS3FileInputPlugin
         }
 
         return clientConfig;
-    }
-
-    private Optional<HttpProxy> createHttpProxyWithDefault(PluginTask task)
-    {
-        // If users configure http proxy in in: section, the settings are used. If http proxy settings
-        // don't exist in the config, it searches and extracts from environment variables: "HTTPS_PROXY",
-        // "https_proxy", "HTTP_PROXY", "http_proxy".
-        return task.getHttpProxy().or(HttpProxy.createHttpProxyFromEnv());
     }
 
     private void setHttpProxyInAwsClient(ClientConfiguration clientConfig, HttpProxy httpProxy)

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
@@ -93,7 +93,7 @@ public abstract class AbstractS3FileInputPlugin
         PluginTask task = config.loadConfig(getTaskClass());
 
         // configure http proxy
-        task.setHttpProxy(setupHttpProxy(task));
+        task.setHttpProxy(createHttpProxyWithDefault(task));
 
         // list files recursively
         task.setFiles(listFiles(task));
@@ -154,21 +154,21 @@ public abstract class AbstractS3FileInputPlugin
 
         // set http proxy
         if (task.getHttpProxy().isPresent()) {
-            setHttpProxy(clientConfig, task.getHttpProxy().get());
+            setHttpProxyInAwsClient(clientConfig, task.getHttpProxy().get());
         }
 
         return clientConfig;
     }
 
-    private Optional<HttpProxy> setupHttpProxy(PluginTask task)
+    private Optional<HttpProxy> createHttpProxyWithDefault(PluginTask task)
     {
         // If users configure http proxy in in: section, the settings are used. If http proxy settings
         // don't exist in the config, it searches and extracts from environment variables: "HTTPS_PROXY",
         // "https_proxy", "HTTP_PROXY", "http_proxy".
-        return task.getHttpProxy().or(HttpProxy.getHttpProxyFromEnv());
+        return task.getHttpProxy().or(HttpProxy.createHttpProxyFromEnv());
     }
 
-    private void setHttpProxy(ClientConfiguration clientConfig, HttpProxy httpProxy)
+    private void setHttpProxyInAwsClient(ClientConfiguration clientConfig, HttpProxy httpProxy)
     {
         // host
         clientConfig.setProxyHost(httpProxy.getHost());

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/HttpProxy.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/HttpProxy.java
@@ -1,0 +1,131 @@
+package org.embulk.input.s3;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Optional;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.util.Map;
+
+/**
+ * HttpProxy is config unit for Input/Output plugins' configs.
+ *
+ * TODO
+ * This unit will be moved to embulk/embulk-plugin-units.git.
+ */
+public class HttpProxy
+{
+    private final String host;
+    private final Optional<Integer> port;
+    private final boolean useSsl;
+    private final Optional<String> user;
+    private final Optional<String> password; // TODO use SecretString
+
+    @JsonCreator
+    public HttpProxy(
+            @JsonProperty("host") String host,
+            @JsonProperty("port") Optional<Integer> port,
+            @JsonProperty("use_ssl") boolean useSsl,
+            @JsonProperty("user") Optional<String> user,
+            @JsonProperty("password") Optional<String> password)
+    {
+        this.host = host;
+        this.port = port;
+        this.useSsl = useSsl;
+        this.user = user;
+        this.password = password;
+    }
+
+    public String getHost()
+    {
+        return host;
+    }
+
+    public Optional<Integer> getPort()
+    {
+        return port;
+    }
+
+    public boolean useSsl()
+    {
+        return useSsl;
+    }
+
+    public Optional<String> getUser()
+    {
+        return user;
+    }
+
+    public Optional<String> getPassword()
+    {
+        return password;
+    }
+
+    /**
+     * Returns http proxy settings from environment variables. It searches environment variables
+     * "HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy" and extracts http proxy settings
+     * in the order.
+     */
+    public static Optional<HttpProxy> getHttpProxyFromEnv()
+    {
+        return getHttpProxyFromEnv("HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy");
+    }
+
+    /**
+     * Returns http proxy settings from environment variables of given names. It searches specified
+     * environment variables and extracts http proxy setting in the order.
+     */
+    public static Optional<HttpProxy> getHttpProxyFromEnv(String... envNames)
+    {
+        Map<String, String> env = System.getenv();
+
+        String envVar = null;
+        for (String envName : envNames) {
+            envVar = env.getOrDefault(envName, "").trim();
+            if (!envVar.isEmpty()) {
+                break;
+            }
+        }
+
+        if (envVar == null) {
+            return Optional.absent();
+        }
+        else {
+            try {
+                return Optional.of(parseHttpProxy(envVar));
+            }
+            catch (URISyntaxException | UnsupportedEncodingException e) {
+                return Optional.absent();
+            }
+        }
+    }
+
+    private static HttpProxy parseHttpProxy(String httpProxyString)
+            throws URISyntaxException, UnsupportedEncodingException
+    {
+        URI uri = new URI(httpProxyString);
+
+        String host = uri.getHost();
+        Optional<Integer> port = uri.getPort() != -1 ? Optional.of(uri.getPort()) : Optional.absent();
+        boolean useSsl = "https".equals(uri.getScheme());
+
+        Optional<String> user = Optional.absent();
+        Optional<String> password = Optional.absent();
+        if (uri.getRawUserInfo() != null) {
+            String rawUserInfo = uri.getRawUserInfo();
+            int colonIndex = rawUserInfo.indexOf(':');
+            if (colonIndex == -1) {
+                user = Optional.of(URLDecoder.decode(rawUserInfo, "UTF-8"));
+            }
+            else {
+                user = Optional.of(rawUserInfo.substring(0, colonIndex));
+                password = Optional.of(rawUserInfo.substring(colonIndex + 1, rawUserInfo.length()));
+            }
+        }
+
+        return new HttpProxy(host, port, useSsl, user, password);
+    }
+}

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/HttpProxy.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/HttpProxy.java
@@ -21,7 +21,7 @@ public class HttpProxy
 {
     private final String host;
     private final Optional<Integer> port;
-    private final boolean useSsl;
+    private final boolean https;
     private final Optional<String> user;
     private final Optional<String> password; // TODO use SecretString
 
@@ -29,13 +29,13 @@ public class HttpProxy
     public HttpProxy(
             @JsonProperty("host") String host,
             @JsonProperty("port") Optional<Integer> port,
-            @JsonProperty("use_ssl") boolean useSsl,
+            @JsonProperty("https") boolean https,
             @JsonProperty("user") Optional<String> user,
             @JsonProperty("password") Optional<String> password)
     {
         this.host = host;
         this.port = port;
-        this.useSsl = useSsl;
+        this.https = https;
         this.user = user;
         this.password = password;
     }
@@ -50,9 +50,9 @@ public class HttpProxy
         return port;
     }
 
-    public boolean useSsl()
+    public boolean useHttps()
     {
-        return useSsl;
+        return https;
     }
 
     public Optional<String> getUser()

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/HttpProxy.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/HttpProxy.java
@@ -109,7 +109,7 @@ public class HttpProxy
         URI uri = new URI(httpProxyString);
 
         String host = uri.getHost();
-        Optional<Integer> port = uri.getPort() != -1 ? Optional.of(uri.getPort()) : Optional.absent();
+        Optional<Integer> port = uri.getPort() != -1 ? Optional.of(uri.getPort()) : Optional.<Integer>absent();
         boolean useSsl = "https".equals(uri.getScheme());
 
         Optional<String> user = Optional.absent();

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/HttpProxy.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/HttpProxy.java
@@ -2,14 +2,7 @@ package org.embulk.input.s3;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
-
-import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URLDecoder;
-import java.util.Map;
 
 /**
  * HttpProxy is config unit for Input/Output plugins' configs.
@@ -63,71 +56,5 @@ public class HttpProxy
     public Optional<String> getPassword()
     {
         return password;
-    }
-
-    /**
-     * Returns http proxy settings from environment variables. It searches environment variables
-     * "HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy" and extracts http proxy settings
-     * in the order.
-     */
-    public static Optional<HttpProxy> createHttpProxyFromEnv()
-    {
-        return createHttpProxyFromEnv("HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy");
-    }
-
-    /**
-     * Returns http proxy settings from environment variables of given names. It searches specified
-     * environment variables and extracts http proxy setting in the order.
-     */
-    public static Optional<HttpProxy> createHttpProxyFromEnv(String... envNames)
-    {
-        Map<String, String> env = System.getenv();
-
-        String envVar = null;
-        for (String envName : envNames) {
-            envVar = env.getOrDefault(envName, "").trim();
-            if (!envVar.isEmpty()) {
-                break;
-            }
-        }
-
-        if (envVar == null) {
-            return Optional.absent();
-        }
-        else {
-            try {
-                return Optional.of(parseHttpProxyFromUrl(envVar));
-            }
-            catch (URISyntaxException | UnsupportedEncodingException e) {
-                return Optional.absent();
-            }
-        }
-    }
-
-    @VisibleForTesting
-    static HttpProxy parseHttpProxyFromUrl(String httpProxyString)
-            throws URISyntaxException, UnsupportedEncodingException
-    {
-        URI uri = new URI(httpProxyString);
-
-        String host = uri.getHost();
-        Optional<Integer> port = uri.getPort() != -1 ? Optional.of(uri.getPort()) : Optional.<Integer>absent();
-        boolean useSsl = "https".equals(uri.getScheme());
-
-        Optional<String> user = Optional.absent();
-        Optional<String> password = Optional.absent();
-        if (uri.getRawUserInfo() != null) {
-            String rawUserInfo = uri.getRawUserInfo();
-            int colonIndex = rawUserInfo.indexOf(':');
-            if (colonIndex == -1) {
-                user = Optional.of(URLDecoder.decode(rawUserInfo, "UTF-8"));
-            }
-            else {
-                user = Optional.of(rawUserInfo.substring(0, colonIndex));
-                password = Optional.of(rawUserInfo.substring(colonIndex + 1, rawUserInfo.length()));
-            }
-        }
-
-        return new HttpProxy(host, port, useSsl, user, password);
     }
 }

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/HttpProxy.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/HttpProxy.java
@@ -70,16 +70,16 @@ public class HttpProxy
      * "HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy" and extracts http proxy settings
      * in the order.
      */
-    public static Optional<HttpProxy> getHttpProxyFromEnv()
+    public static Optional<HttpProxy> createHttpProxyFromEnv()
     {
-        return getHttpProxyFromEnv("HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy");
+        return createHttpProxyFromEnv("HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy");
     }
 
     /**
      * Returns http proxy settings from environment variables of given names. It searches specified
      * environment variables and extracts http proxy setting in the order.
      */
-    public static Optional<HttpProxy> getHttpProxyFromEnv(String... envNames)
+    public static Optional<HttpProxy> createHttpProxyFromEnv(String... envNames)
     {
         Map<String, String> env = System.getenv();
 
@@ -96,7 +96,7 @@ public class HttpProxy
         }
         else {
             try {
-                return Optional.of(parseHttpProxy(envVar));
+                return Optional.of(parseHttpProxyFromUrl(envVar));
             }
             catch (URISyntaxException | UnsupportedEncodingException e) {
                 return Optional.absent();
@@ -105,7 +105,7 @@ public class HttpProxy
     }
 
     @VisibleForTesting
-    static HttpProxy parseHttpProxy(String httpProxyString)
+    static HttpProxy parseHttpProxyFromUrl(String httpProxyString)
             throws URISyntaxException, UnsupportedEncodingException
     {
         URI uri = new URI(httpProxyString);

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/HttpProxy.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/HttpProxy.java
@@ -2,6 +2,7 @@ package org.embulk.input.s3;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 
 import java.io.UnsupportedEncodingException;
@@ -103,7 +104,8 @@ public class HttpProxy
         }
     }
 
-    private static HttpProxy parseHttpProxy(String httpProxyString)
+    @VisibleForTesting
+    static HttpProxy parseHttpProxy(String httpProxyString)
             throws URISyntaxException, UnsupportedEncodingException
     {
         URI uri = new URI(httpProxyString);

--- a/embulk-input-s3/src/test/java/org/embulk/input/s3/TestHttpProxy.java
+++ b/embulk-input-s3/src/test/java/org/embulk/input/s3/TestHttpProxy.java
@@ -1,0 +1,160 @@
+package org.embulk.input.s3;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
+import org.embulk.EmbulkTestRuntime;
+import org.embulk.config.ConfigSource;
+import org.embulk.input.s3.S3FileInputPlugin.S3PluginTask;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.net.URISyntaxException;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class TestHttpProxy
+{
+    @Rule
+    public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
+
+    private ConfigSource config;
+
+    @Before
+    public void createResources()
+    {
+        config = runtime.getExec().newConfigSource();
+        setupS3Config(config);
+    }
+
+    @Test
+    public void checkDefaultHttpProxy()
+    {
+        ConfigSource conf = config.deepCopy();
+        setupS3Config(conf);
+        S3PluginTask task = conf.loadConfig(S3PluginTask.class);
+        assertTrue(!task.getHttpProxy().isPresent());
+    }
+
+    @Test
+    public void checkHttpProxy()
+    {
+        { // specify host
+            String host = "my_host";
+            Map<String, Object> httpProxyMap = ImmutableMap.<String, Object>of("host", host);
+            ConfigSource conf = config.deepCopy().set("http_proxy", httpProxyMap);
+            S3PluginTask task = conf.loadConfig(S3PluginTask.class);
+
+            assertHttpProxy(new HttpProxy(host, Optional.<Integer>absent(), false, Optional.<String>absent(), Optional.<String>absent()),
+                    task.getHttpProxy().get());
+        }
+
+        { // specify host, port, use_ssl
+            String host = "my_host";
+            int port = 8080;
+            boolean useSsl = true;
+            Map<String, Object> httpProxyMap = ImmutableMap.<String, Object>of(
+                    "host", host,
+                    "port", 8080,
+                    "use_ssl", true);
+            ConfigSource conf = config.deepCopy().set("http_proxy", httpProxyMap);
+            S3PluginTask task = conf.loadConfig(S3PluginTask.class);
+
+            assertHttpProxy(new HttpProxy(host, Optional.of(port), true, Optional.<String>absent(), Optional.<String>absent()),
+                    task.getHttpProxy().get());
+        }
+
+        { // specify host, port, use_ssl, user, password
+            String host = "my_host";
+            int port = 8080;
+            boolean useSsl = true;
+            String user = "my_user";
+            String password = "my_pass";
+            Map<String, Object> httpProxyMap = ImmutableMap.<String, Object>of(
+                    "host", host,
+                    "port", 8080,
+                    "use_ssl", true,
+                    "user", user,
+                    "password", password);
+            ConfigSource conf = config.deepCopy().set("http_proxy", httpProxyMap);
+            S3PluginTask task = conf.loadConfig(S3PluginTask.class);
+
+            assertHttpProxy(new HttpProxy(host, Optional.of(port), true, Optional.of(user), Optional.of(password)),
+                    task.getHttpProxy().get());
+        }
+    }
+
+    @Test
+    public void parseHttpProxy()
+            throws Exception
+    {
+        String httpProxyString;
+
+        {
+            httpProxyString = "https://my.local.com:8080";
+            assertHttpProxy(new HttpProxy("my.local.com", Optional.of(8080), true, Optional.<String>absent(), Optional.<String>absent()),
+                    HttpProxy.parseHttpProxy(httpProxyString));
+        }
+
+        {
+            httpProxyString = "https://my.local.com";
+            assertHttpProxy(new HttpProxy("my.local.com", Optional.<Integer>absent(), true, Optional.<String>absent(), Optional.<String>absent()),
+                    HttpProxy.parseHttpProxy(httpProxyString));
+        }
+
+        {
+            httpProxyString = "http://my.local.com:8080";
+            assertHttpProxy(new HttpProxy("my.local.com", Optional.of(8080), false, Optional.<String>absent(), Optional.<String>absent()),
+                    HttpProxy.parseHttpProxy(httpProxyString));
+        }
+
+        {
+            httpProxyString = "https://my_user@my.local.com:8080";
+            assertHttpProxy(new HttpProxy("my.local.com", Optional.of(8080), true, Optional.of("my_user"), Optional.<String>absent()),
+                    HttpProxy.parseHttpProxy(httpProxyString));
+        }
+
+        {
+            httpProxyString = "https://my_user:my_pass@my.local.com:8080";
+            assertHttpProxy(new HttpProxy("my.local.com", Optional.of(8080), true, Optional.of("my_user"), Optional.of("my_pass")),
+                    HttpProxy.parseHttpProxy(httpProxyString));
+        }
+
+        { // invalid uri
+            httpProxyString = ":";
+            try {
+                HttpProxy.parseHttpProxy(httpProxyString);
+                fail();
+            }
+            catch (Throwable t) {
+                assertTrue(t instanceof URISyntaxException);
+            }
+        }
+    }
+
+    private static void setupS3Config(ConfigSource config)
+    {
+        config.set("bucket", "my_bucket").set("path_prefix", "my_path_prefix");
+    }
+
+    private static void assertHttpProxy(HttpProxy expected, HttpProxy actual)
+    {
+        assertEquals(expected.getHost(), actual.getHost());
+        assertEquals(expected.getPort().isPresent(), actual.getPort().isPresent());
+        if (expected.getPort().isPresent()) {
+            assertEquals(expected.getPort().get(), actual.getPort().get());
+        }
+        assertEquals(expected.useSsl(), actual.useSsl());
+        assertEquals(expected.getUser().isPresent(), actual.getUser().isPresent());
+        if (expected.getUser().isPresent()) {
+            assertEquals(expected.getUser().get(), actual.getUser().get());
+        }
+        assertEquals(expected.getPassword().isPresent(), actual.getPassword().isPresent());
+        if (expected.getPassword().isPresent()) {
+            assertEquals(expected.getPassword().get(), actual.getPassword().get());
+        }
+    }
+}

--- a/embulk-input-s3/src/test/java/org/embulk/input/s3/TestHttpProxy.java
+++ b/embulk-input-s3/src/test/java/org/embulk/input/s3/TestHttpProxy.java
@@ -59,7 +59,7 @@ public class TestHttpProxy
             Map<String, Object> httpProxyMap = ImmutableMap.<String, Object>of(
                     "host", host,
                     "port", 8080,
-                    "use_ssl", true);
+                    "https", true);
             ConfigSource conf = config.deepCopy().set("http_proxy", httpProxyMap);
             S3PluginTask task = conf.loadConfig(S3PluginTask.class);
 
@@ -76,7 +76,7 @@ public class TestHttpProxy
             Map<String, Object> httpProxyMap = ImmutableMap.<String, Object>of(
                     "host", host,
                     "port", 8080,
-                    "use_ssl", true,
+                    "https", true,
                     "user", user,
                     "password", password);
             ConfigSource conf = config.deepCopy().set("http_proxy", httpProxyMap);
@@ -84,54 +84,6 @@ public class TestHttpProxy
 
             assertHttpProxy(new HttpProxy(host, Optional.of(port), true, Optional.of(user), Optional.of(password)),
                     task.getHttpProxy().get());
-        }
-    }
-
-    @Test
-    public void parseHttpProxy()
-            throws Exception
-    {
-        String httpProxyString;
-
-        {
-            httpProxyString = "https://my.local.com:8080";
-            assertHttpProxy(new HttpProxy("my.local.com", Optional.of(8080), true, Optional.<String>absent(), Optional.<String>absent()),
-                    HttpProxy.parseHttpProxyFromUrl(httpProxyString));
-        }
-
-        {
-            httpProxyString = "https://my.local.com";
-            assertHttpProxy(new HttpProxy("my.local.com", Optional.<Integer>absent(), true, Optional.<String>absent(), Optional.<String>absent()),
-                    HttpProxy.parseHttpProxyFromUrl(httpProxyString));
-        }
-
-        {
-            httpProxyString = "http://my.local.com:8080";
-            assertHttpProxy(new HttpProxy("my.local.com", Optional.of(8080), false, Optional.<String>absent(), Optional.<String>absent()),
-                    HttpProxy.parseHttpProxyFromUrl(httpProxyString));
-        }
-
-        {
-            httpProxyString = "https://my_user@my.local.com:8080";
-            assertHttpProxy(new HttpProxy("my.local.com", Optional.of(8080), true, Optional.of("my_user"), Optional.<String>absent()),
-                    HttpProxy.parseHttpProxyFromUrl(httpProxyString));
-        }
-
-        {
-            httpProxyString = "https://my_user:my_pass@my.local.com:8080";
-            assertHttpProxy(new HttpProxy("my.local.com", Optional.of(8080), true, Optional.of("my_user"), Optional.of("my_pass")),
-                    HttpProxy.parseHttpProxyFromUrl(httpProxyString));
-        }
-
-        { // invalid uri
-            httpProxyString = ":";
-            try {
-                HttpProxy.parseHttpProxyFromUrl(httpProxyString);
-                fail();
-            }
-            catch (Throwable t) {
-                assertTrue(t instanceof URISyntaxException);
-            }
         }
     }
 

--- a/embulk-input-s3/src/test/java/org/embulk/input/s3/TestHttpProxy.java
+++ b/embulk-input-s3/src/test/java/org/embulk/input/s3/TestHttpProxy.java
@@ -147,7 +147,7 @@ public class TestHttpProxy
         if (expected.getPort().isPresent()) {
             assertEquals(expected.getPort().get(), actual.getPort().get());
         }
-        assertEquals(expected.useSsl(), actual.useSsl());
+        assertEquals(expected.useHttps(), actual.useHttps());
         assertEquals(expected.getUser().isPresent(), actual.getUser().isPresent());
         if (expected.getUser().isPresent()) {
             assertEquals(expected.getUser().get(), actual.getUser().get());

--- a/embulk-input-s3/src/test/java/org/embulk/input/s3/TestHttpProxy.java
+++ b/embulk-input-s3/src/test/java/org/embulk/input/s3/TestHttpProxy.java
@@ -96,37 +96,37 @@ public class TestHttpProxy
         {
             httpProxyString = "https://my.local.com:8080";
             assertHttpProxy(new HttpProxy("my.local.com", Optional.of(8080), true, Optional.<String>absent(), Optional.<String>absent()),
-                    HttpProxy.parseHttpProxy(httpProxyString));
+                    HttpProxy.parseHttpProxyFromUrl(httpProxyString));
         }
 
         {
             httpProxyString = "https://my.local.com";
             assertHttpProxy(new HttpProxy("my.local.com", Optional.<Integer>absent(), true, Optional.<String>absent(), Optional.<String>absent()),
-                    HttpProxy.parseHttpProxy(httpProxyString));
+                    HttpProxy.parseHttpProxyFromUrl(httpProxyString));
         }
 
         {
             httpProxyString = "http://my.local.com:8080";
             assertHttpProxy(new HttpProxy("my.local.com", Optional.of(8080), false, Optional.<String>absent(), Optional.<String>absent()),
-                    HttpProxy.parseHttpProxy(httpProxyString));
+                    HttpProxy.parseHttpProxyFromUrl(httpProxyString));
         }
 
         {
             httpProxyString = "https://my_user@my.local.com:8080";
             assertHttpProxy(new HttpProxy("my.local.com", Optional.of(8080), true, Optional.of("my_user"), Optional.<String>absent()),
-                    HttpProxy.parseHttpProxy(httpProxyString));
+                    HttpProxy.parseHttpProxyFromUrl(httpProxyString));
         }
 
         {
             httpProxyString = "https://my_user:my_pass@my.local.com:8080";
             assertHttpProxy(new HttpProxy("my.local.com", Optional.of(8080), true, Optional.of("my_user"), Optional.of("my_pass")),
-                    HttpProxy.parseHttpProxy(httpProxyString));
+                    HttpProxy.parseHttpProxyFromUrl(httpProxyString));
         }
 
         { // invalid uri
             httpProxyString = ":";
             try {
-                HttpProxy.parseHttpProxy(httpProxyString);
+                HttpProxy.parseHttpProxyFromUrl(httpProxyString);
                 fail();
             }
             catch (Throwable t) {


### PR DESCRIPTION
This PR is motivated by https://github.com/embulk/embulk-input-s3/pull/12 and supports http proxy settings for S3InputPlugin. It introduces HttpProxy class, which is config unit represents http proxy settings. 

HttpProxy is for this plugin for now but, the class could be used for any input/output plugins. It will be moved to embulk/embulk.git or other repo like embulk-plugin-units.git.

HttpProxy has static method `getHttpProxyFromEnv` that extracts http proxy settings from environment variables. Configuring http proxying using environment variables is not standardized but commonly used.