### PR TITLE
Set http_proxy.https option to true by default

### DIFF
--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
@@ -43,6 +43,9 @@ import org.embulk.spi.util.RetryExecutor.Retryable;
 import org.embulk.spi.util.RetryExecutor.RetryGiveupException;
 import org.embulk.util.aws.credentials.AwsCredentials;
 import org.embulk.util.aws.credentials.AwsCredentialsTask;
+
+import static com.amazonaws.Protocol.HTTP;
+import static com.amazonaws.Protocol.HTTPS;
 import static org.embulk.spi.util.RetryExecutor.retryExecutor;
 
 public abstract class AbstractS3FileInputPlugin
@@ -167,8 +170,13 @@ public abstract class AbstractS3FileInputPlugin
             clientConfig.setProxyPort(httpProxy.getPort().get());
         }
 
-        // useHttps
-        clientConfig.setProtocol(httpProxy.useHttps() ? Protocol.HTTPS : Protocol.HTTP);
+        // https
+        if (httpProxy.useHttps().isPresent()) {
+            clientConfig.setProtocol(httpProxy.useHttps().get() ? HTTPS : HTTP);
+        }
+        else { // use HTTPS by default
+            clientConfig.setProtocol(HTTPS);
+        }
 
         // user
         if (httpProxy.getUser().isPresent()) {

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
@@ -171,12 +171,7 @@ public abstract class AbstractS3FileInputPlugin
         }
 
         // https
-        if (httpProxy.useHttps().isPresent()) {
-            clientConfig.setProtocol(httpProxy.useHttps().get() ? HTTPS : HTTP);
-        }
-        else { // use HTTPS by default
-            clientConfig.setProtocol(HTTPS);
-        }
+        clientConfig.setProtocol(httpProxy.getHttps() ? Protocol.HTTPS : Protocol.HTTP);
 
         // user
         if (httpProxy.getUser().isPresent()) {

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/HttpProxy.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/HttpProxy.java
@@ -14,7 +14,7 @@ public class HttpProxy
 {
     private final String host;
     private final Optional<Integer> port;
-    private final boolean https;
+    private final Optional<Boolean> https;
     private final Optional<String> user;
     private final Optional<String> password; // TODO use SecretString
 
@@ -22,7 +22,7 @@ public class HttpProxy
     public HttpProxy(
             @JsonProperty("host") String host,
             @JsonProperty("port") Optional<Integer> port,
-            @JsonProperty("https") boolean https,
+            @JsonProperty("https") Optional<Boolean> https,
             @JsonProperty("user") Optional<String> user,
             @JsonProperty("password") Optional<String> password)
     {
@@ -43,7 +43,7 @@ public class HttpProxy
         return port;
     }
 
-    public boolean useHttps()
+    public Optional<Boolean> useHttps()
     {
         return https;
     }

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/HttpProxy.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/HttpProxy.java
@@ -1,8 +1,9 @@
 package org.embulk.input.s3;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
+import org.embulk.config.Config;
+import org.embulk.config.ConfigDefault;
+import org.embulk.config.Task;
 
 /**
  * HttpProxy is config unit for Input/Output plugins' configs.
@@ -10,11 +11,32 @@ import com.google.common.base.Optional;
  * TODO
  * This unit will be moved to embulk/embulk-plugin-units.git.
  */
-public class HttpProxy
+public interface HttpProxy
+    extends Task
 {
+    @Config("host")
+    public String getHost();
+
+    @Config("port")
+    @ConfigDefault("null")
+    public Optional<Integer> getPort();
+
+    @Config("https")
+    @ConfigDefault("true")
+    public boolean getHttps();
+
+    @Config("user")
+    @ConfigDefault("null")
+    public Optional<String> getUser();
+
+    @Config("password")
+    @ConfigDefault("null")
+    public Optional<String> getPassword();
+
+    /* TODO We can use this by jackson-core v2.6
     private final String host;
     private final Optional<Integer> port;
-    private final Optional<Boolean> https;
+    private final boolean https;
     private final Optional<String> user;
     private final Optional<String> password; // TODO use SecretString
 
@@ -22,7 +44,7 @@ public class HttpProxy
     public HttpProxy(
             @JsonProperty("host") String host,
             @JsonProperty("port") Optional<Integer> port,
-            @JsonProperty("https") Optional<Boolean> https,
+            @JsonProperty(defaultValue = "true", value = "https", required = false) boolean https,
             @JsonProperty("user") Optional<String> user,
             @JsonProperty("password") Optional<String> password)
     {
@@ -32,29 +54,5 @@ public class HttpProxy
         this.user = user;
         this.password = password;
     }
-
-    public String getHost()
-    {
-        return host;
-    }
-
-    public Optional<Integer> getPort()
-    {
-        return port;
-    }
-
-    public Optional<Boolean> useHttps()
-    {
-        return https;
-    }
-
-    public Optional<String> getUser()
-    {
-        return user;
-    }
-
-    public Optional<String> getPassword()
-    {
-        return password;
-    }
+    */
 }

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/HttpProxy.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/HttpProxy.java
@@ -33,7 +33,8 @@ public interface HttpProxy
     @ConfigDefault("null")
     public Optional<String> getPassword();
 
-    /* TODO We can use this by jackson-core v2.6
+    // TODO: Consider using @JsonProperty(defaultValue=...) in Jackson 2.6+.
+    /*
     private final String host;
     private final Optional<Integer> port;
     private final boolean https;

--- a/embulk-input-s3/src/test/java/org/embulk/input/s3/TestHttpProxy.java
+++ b/embulk-input-s3/src/test/java/org/embulk/input/s3/TestHttpProxy.java
@@ -1,7 +1,6 @@
 package org.embulk.input.s3;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableMap;
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigSource;
 import org.embulk.input.s3.S3FileInputPlugin.S3PluginTask;
@@ -9,12 +8,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.net.URISyntaxException;
-import java.util.Map;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class TestHttpProxy
 {
@@ -44,46 +39,56 @@ public class TestHttpProxy
     {
         { // specify host
             String host = "my_host";
-            Map<String, Object> httpProxyMap = ImmutableMap.<String, Object>of("host", host);
-            ConfigSource conf = config.deepCopy().set("http_proxy", httpProxyMap);
-            S3PluginTask task = conf.loadConfig(S3PluginTask.class);
-
-            assertHttpProxy(new HttpProxy(host, Optional.<Integer>absent(), Optional.<Boolean>absent(), Optional.<String>absent(), Optional.<String>absent()),
-                    task.getHttpProxy().get());
+            ConfigSource conf = config.deepCopy().set("host", host);
+            HttpProxy httpProxy = conf.loadConfig(HttpProxy.class);
+            assertHttpProxy(host, Optional.<Integer>absent(), true, Optional.<String>absent(), Optional.<String>absent(),
+                    httpProxy);
         }
 
-        { // specify host, port, use_ssl
+        { // specify https=true explicitly
             String host = "my_host";
-            int port = 8080;
-            boolean useSsl = true;
-            Map<String, Object> httpProxyMap = ImmutableMap.<String, Object>of(
-                    "host", host,
-                    "port", 8080,
-                    "https", true);
-            ConfigSource conf = config.deepCopy().set("http_proxy", httpProxyMap);
-            S3PluginTask task = conf.loadConfig(S3PluginTask.class);
-
-            assertHttpProxy(new HttpProxy(host, Optional.of(port), Optional.of(true), Optional.<String>absent(), Optional.<String>absent()),
-                    task.getHttpProxy().get());
+            ConfigSource conf = config.deepCopy()
+                    .set("host", host)
+                    .set("https", true);
+            HttpProxy httpProxy = conf.loadConfig(HttpProxy.class);
+            assertHttpProxy(host, Optional.<Integer>absent(), true, Optional.<String>absent(), Optional.<String>absent(),
+                    httpProxy);
         }
 
-        { // specify host, port, use_ssl, user, password
+        { // specify https=false
+            String host = "my_host";
+            ConfigSource conf = config.deepCopy()
+                    .set("host", host)
+                    .set("https", false);
+            HttpProxy httpProxy = conf.loadConfig(HttpProxy.class);
+            assertHttpProxy(host, Optional.<Integer>absent(), false, Optional.<String>absent(), Optional.<String>absent(),
+                    httpProxy);
+        }
+
+        { // specify host, port
             String host = "my_host";
             int port = 8080;
-            boolean useSsl = true;
+            ConfigSource conf = config.deepCopy()
+                    .set("host", host)
+                    .set("port", port);
+            HttpProxy httpProxy = conf.loadConfig(HttpProxy.class);
+            assertHttpProxy(host, Optional.of(port), true, Optional.<String>absent(), Optional.<String>absent(),
+                    httpProxy);
+        }
+
+        { // specify host, port, user, password
+            String host = "my_host";
+            int port = 8080;
             String user = "my_user";
             String password = "my_pass";
-            Map<String, Object> httpProxyMap = ImmutableMap.<String, Object>of(
-                    "host", host,
-                    "port", 8080,
-                    "https", true,
-                    "user", user,
-                    "password", password);
-            ConfigSource conf = config.deepCopy().set("http_proxy", httpProxyMap);
-            S3PluginTask task = conf.loadConfig(S3PluginTask.class);
-
-            assertHttpProxy(new HttpProxy(host, Optional.of(port), Optional.of(true), Optional.of(user), Optional.of(password)),
-                    task.getHttpProxy().get());
+            ConfigSource conf = config.deepCopy()
+                    .set("host", host)
+                    .set("port", port)
+                    .set("user", user)
+                    .set("password", password);
+            HttpProxy httpProxy = conf.loadConfig(HttpProxy.class);
+            assertHttpProxy(host, Optional.of(port), true, Optional.of(user), Optional.of(password),
+                    httpProxy);
         }
     }
 
@@ -92,24 +97,24 @@ public class TestHttpProxy
         config.set("bucket", "my_bucket").set("path_prefix", "my_path_prefix");
     }
 
-    private static void assertHttpProxy(HttpProxy expected, HttpProxy actual)
+    private static void assertHttpProxy(String host, Optional<Integer> port, boolean https, Optional<String> user, Optional<String> password,
+            HttpProxy actual)
     {
-        assertEquals(expected.getHost(), actual.getHost());
-        assertEquals(expected.getPort().isPresent(), actual.getPort().isPresent());
-        if (expected.getPort().isPresent()) {
-            assertEquals(expected.getPort().get(), actual.getPort().get());
-        }
-        if (expected.useHttps().isPresent()) {
-            assertEquals(expected.useHttps().get(), actual.useHttps().get());
+        assertEquals(host, actual.getHost());
+        assertEquals(port.isPresent(), actual.getPort().isPresent());
+        if (port.isPresent()) {
+            assertEquals(port.get(), actual.getPort().get());
         }
 
-        assertEquals(expected.getUser().isPresent(), actual.getUser().isPresent());
-        if (expected.getUser().isPresent()) {
-            assertEquals(expected.getUser().get(), actual.getUser().get());
+        assertEquals(https, actual.getHttps());
+
+        assertEquals(user.isPresent(), actual.getUser().isPresent());
+        if (user.isPresent()) {
+            assertEquals(user.get(), actual.getUser().get());
         }
-        assertEquals(expected.getPassword().isPresent(), actual.getPassword().isPresent());
-        if (expected.getPassword().isPresent()) {
-            assertEquals(expected.getPassword().get(), actual.getPassword().get());
+        assertEquals(password.isPresent(), actual.getPassword().isPresent());
+        if (password.isPresent()) {
+            assertEquals(password.get(), actual.getPassword().get());
         }
     }
 }

--- a/embulk-input-s3/src/test/java/org/embulk/input/s3/TestHttpProxy.java
+++ b/embulk-input-s3/src/test/java/org/embulk/input/s3/TestHttpProxy.java
@@ -48,7 +48,7 @@ public class TestHttpProxy
             ConfigSource conf = config.deepCopy().set("http_proxy", httpProxyMap);
             S3PluginTask task = conf.loadConfig(S3PluginTask.class);
 
-            assertHttpProxy(new HttpProxy(host, Optional.<Integer>absent(), false, Optional.<String>absent(), Optional.<String>absent()),
+            assertHttpProxy(new HttpProxy(host, Optional.<Integer>absent(), Optional.<Boolean>absent(), Optional.<String>absent(), Optional.<String>absent()),
                     task.getHttpProxy().get());
         }
 
@@ -63,7 +63,7 @@ public class TestHttpProxy
             ConfigSource conf = config.deepCopy().set("http_proxy", httpProxyMap);
             S3PluginTask task = conf.loadConfig(S3PluginTask.class);
 
-            assertHttpProxy(new HttpProxy(host, Optional.of(port), true, Optional.<String>absent(), Optional.<String>absent()),
+            assertHttpProxy(new HttpProxy(host, Optional.of(port), Optional.of(true), Optional.<String>absent(), Optional.<String>absent()),
                     task.getHttpProxy().get());
         }
 
@@ -82,7 +82,7 @@ public class TestHttpProxy
             ConfigSource conf = config.deepCopy().set("http_proxy", httpProxyMap);
             S3PluginTask task = conf.loadConfig(S3PluginTask.class);
 
-            assertHttpProxy(new HttpProxy(host, Optional.of(port), true, Optional.of(user), Optional.of(password)),
+            assertHttpProxy(new HttpProxy(host, Optional.of(port), Optional.of(true), Optional.of(user), Optional.of(password)),
                     task.getHttpProxy().get());
         }
     }
@@ -99,7 +99,10 @@ public class TestHttpProxy
         if (expected.getPort().isPresent()) {
             assertEquals(expected.getPort().get(), actual.getPort().get());
         }
-        assertEquals(expected.useHttps(), actual.useHttps());
+        if (expected.useHttps().isPresent()) {
+            assertEquals(expected.useHttps().get(), actual.useHttps().get());
+        }
+
         assertEquals(expected.getUser().isPresent(), actual.getUser().isPresent());
         if (expected.getUser().isPresent()) {
             assertEquals(expected.getUser().get(), actual.getUser().get());


### PR DESCRIPTION
This PR sets `http_proxy.https` option to `true` by default. Because HTTPS is used commonly.