### PR TITLE
Upgrade aws-java-sdk-s3 from 1.10.33 to 1.10.77

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,9 +63,9 @@ subprojects {
     dependencies {
         compile  "org.embulk:embulk-core:0.8.18"
         provided "org.embulk:embulk-core:0.8.18"
-        compile "com.amazonaws:aws-java-sdk-s3:1.10.33"
+        compile "com.amazonaws:aws-java-sdk-s3:1.10.77"
         runtime "org.slf4j:jcl-over-slf4j:1.7.12"  // aws-sdk uses Apache Commons Logging and Embulk uses slf4j
-        testCompile "com.amazonaws:aws-java-sdk-sts:1.10.33"
+        testCompile "com.amazonaws:aws-java-sdk-sts:1.10.77"
         testCompile "junit:junit:4.+"
         testCompile "org.mockito:mockito-core:1.+"
         testCompile "org.embulk:embulk-standards:0.8.18"


### PR DESCRIPTION
This PR upgrades latest 1.10.x of aws-java-sdk-s3. I took a look the diff between 1.10.33 and 1.10.77 and it seems that there're not any changes that break API compatibility. 
https://github.com/aws/aws-sdk-java/compare/1.10.33...1.10.77