### PR TITLE
add skip_glacier_object option to avoid loading a object stored at glacier

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@
 
 * **incremental**: enables incremental loading. If incremental loading is enabled, config diff for the next execution will include `last_path` parameter so that next execution skips files before the path. Otherwise, `last_path` will not be included.
 
+* **skip_glacier_objects**: if true, skip processing objects stored in Amazon Glacier (boolean, default false)
+
 ## Example
 
 ```yaml

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
@@ -22,7 +22,6 @@ import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
-import org.embulk.config.ConfigException;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.Protocol;

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
@@ -241,10 +241,10 @@ public abstract class AbstractS3FileInputPlugin
             for (S3ObjectSummary s : ol.getObjectSummaries()) {
                 if (s.getStorageClass().equals(StorageClass.Glacier.toString())) {
                     if (skipGlacierObject) {
-                        Exec.getLogger("AbstractS3FileInputPlugin.class").warn("Skipped \"s3://{}/{}\" that stored at Gracier.", bucketName, s.getKey());
+                        Exec.getLogger("AbstractS3FileInputPlugin.class").warn("Skipped \"s3://{}/{}\" that stored at Glacier.", bucketName, s.getKey());
                         continue;
                     } else {
-                        throw new ConfigException("Detected an object stored at Gracier. Set \"skip_glacier_object\" option to \"true\" to skip this.");
+                        throw new ConfigException("Detected an object stored at Glacier. Set \"skip_glacier_object\" option to \"true\" to skip this.");
                     }
                 }
                 if (s.getSize() > 0) {

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
@@ -75,9 +75,9 @@ public abstract class AbstractS3FileInputPlugin
         @ConfigDefault("true")
         public boolean getIncremental();
 
-        @Config("skip_glacier_object")
+        @Config("skip_glacier_objects")
         @ConfigDefault("false")
-        public boolean getSkipGlacierObject();
+        public boolean getSkipGlacierObjects();
 
         // TODO timeout, ssl, etc
 
@@ -211,7 +211,7 @@ public abstract class AbstractS3FileInputPlugin
 
             FileList.Builder builder = new FileList.Builder(task);
             listS3FilesByPrefix(builder, client, bucketName,
-                    task.getPathPrefix(), task.getLastPath(), task.getSkipGlacierObject());
+                    task.getPathPrefix(), task.getLastPath(), task.getSkipGlacierObjects());
             return builder.build();
         }
         catch (AmazonServiceException ex) {
@@ -234,7 +234,7 @@ public abstract class AbstractS3FileInputPlugin
      */
     public static void listS3FilesByPrefix(FileList.Builder builder,
             AmazonS3 client, String bucketName,
-            String prefix, Optional<String> lastPath, boolean skipGlacierObject)
+            String prefix, Optional<String> lastPath, boolean skipGlacierObjects)
     {
         String lastKey = lastPath.orNull();
         do {
@@ -242,11 +242,11 @@ public abstract class AbstractS3FileInputPlugin
             ObjectListing ol = client.listObjects(req);
             for (S3ObjectSummary s : ol.getObjectSummaries()) {
                 if (s.getStorageClass().equals(StorageClass.Glacier.toString())) {
-                    if (skipGlacierObject) {
+                    if (skipGlacierObjects) {
                         Exec.getLogger("AbstractS3FileInputPlugin.class").warn("Skipped \"s3://{}/{}\" that stored at Glacier.", bucketName, s.getKey());
                         continue;
                     } else {
-                        throw new ConfigException("Detected an object stored at Glacier. Set \"skip_glacier_object\" option to \"true\" to skip this.");
+                        throw new ConfigException("Detected an object stored at Glacier. Set \"skip_glacier_objects\" option to \"true\" to skip this.");
                     }
                 }
                 if (s.getSize() > 0) {

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
@@ -368,11 +368,10 @@ public abstract class AbstractS3FileInputPlugin
                 S3Object obj = client.getObject(request);
                 return new ResumableInputStream(obj.getObjectContent(), new S3InputStreamReopener(client, request, obj.getObjectMetadata().getContentLength()));
             } catch (AmazonS3Exception ex) {
-                 int statusCode = ex.getStatusCode();
                 // HTTP 403 errors caused by a glacier object.
-                if (statusCode == 403 && "InvalidObjectState".equalsIgnoreCase(ex.getErrorCode())) {
+                if (ex.getStatusCode() == 403 && "InvalidObjectState".equalsIgnoreCase(ex.getErrorCode())) {
                     if (this.skip_glacier_object) {
-                        log.warn("Skipped \"s3://{}/{}\" that stored at Gracier. status code: {}", this.bucket, request.getKey(), statusCode);
+                        log.warn("Skipped \"s3://{}/{}\" that stored at Gracier. status code: {}", this.bucket, request.getKey(), ex.getStatusCode());
                         return null;
                     } else {
                         throw new ConfigException(ex);

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
@@ -368,10 +368,11 @@ public abstract class AbstractS3FileInputPlugin
                 S3Object obj = client.getObject(request);
                 return new ResumableInputStream(obj.getObjectContent(), new S3InputStreamReopener(client, request, obj.getObjectMetadata().getContentLength()));
             } catch (AmazonS3Exception ex) {
+                 int statusCode = ex.getStatusCode();
                 // HTTP 403 errors caused by a glacier object.
-                if (ex.getStatusCode() == 403 && "InvalidObjectState".equalsIgnoreCase(ex.getErrorCode())) {
+                if (statusCode == 403 && "InvalidObjectState".equalsIgnoreCase(ex.getErrorCode())) {
                     if (this.skip_glacier_object) {
-                        log.warn("Skipped \"s3://{}/{}\" that stored at Gracier. status code: {}", this.bucket, request.getKey(), ex.getStatusCode());
+                        log.warn("Skipped \"s3://{}/{}\" that stored at Gracier. status code: {}", this.bucket, request.getKey(), statusCode);
                         return null;
                     } else {
                         throw new ConfigException(ex);

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
@@ -368,10 +368,11 @@ public abstract class AbstractS3FileInputPlugin
                 S3Object obj = client.getObject(request);
                 return new ResumableInputStream(obj.getObjectContent(), new S3InputStreamReopener(client, request, obj.getObjectMetadata().getContentLength()));
             } catch (AmazonS3Exception ex) {
+                int statusCode = ex.getStatusCode();
                 // HTTP 403 errors caused by a glacier object.
-                if (ex.getStatusCode() == 403 && "InvalidObjectState".equalsIgnoreCase(ex.getErrorCode())) {
+                if (statusCode == 403 && "InvalidObjectState".equalsIgnoreCase(ex.getErrorCode())) {
                     if (this.skip_glacier_object) {
-                        log.warn("Skipped \"s3://{}/{}\" that stored at Gracier. status code: {}", this.bucket, request.getKey(), ex.getStatusCode());
+                        log.warn("Skipped \"s3://{}/{}\" that stored at Gracier. status code: {}", this.bucket, request.getKey(), statusCode);
                         return null;
                     } else {
                         throw new ConfigException(ex);

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
@@ -21,6 +21,7 @@ import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.Protocol;
@@ -353,9 +354,14 @@ public abstract class AbstractS3FileInputPlugin
             if (!iterator.hasNext()) {
                 return null;
             }
-            GetObjectRequest request = new GetObjectRequest(bucket, iterator.next());
-            S3Object obj = client.getObject(request);
-            return new ResumableInputStream(obj.getObjectContent(), new S3InputStreamReopener(client, request, obj.getObjectMetadata().getContentLength()));
+
+            try {
+                GetObjectRequest request = new GetObjectRequest(bucket, iterator.next());
+                S3Object obj = client.getObject(request);
+                return new ResumableInputStream(obj.getObjectContent(), new S3InputStreamReopener(client, request, obj.getObjectMetadata().getContentLength()));
+            } catch (AmazonS3Exception ex) {
+                return null;
+            }
         }
 
         @Override

--- a/embulk-input-s3/src/test/java/org/embulk/input/s3/TestS3FileInputPlugin.java
+++ b/embulk-input-s3/src/test/java/org/embulk/input/s3/TestS3FileInputPlugin.java
@@ -206,7 +206,7 @@ public class TestS3FileInputPlugin
     }
   
     @Test(expected = ConfigException.class)
-    public void useSkipGracierObject() throws Exception
+    public void useSkipGlacierObjects() throws Exception
     {
         AmazonS3 client;
         client = mock(AmazonS3.class);


### PR DESCRIPTION
A getObject method throws an AmazonS3Exception when a target S3 path contains a object whose storage class is "Glacier". 

This PR handles above Exception.

```
try {
    GetObjectRequest request = new GetObjectRequest(bucket, iterator.next());
    S3Object obj = client.getObject(request);
    return new ResumableInputStream(obj.getObjectContent(), new S3InputStreamReopener(client, request, obj.getObjectMetadata().getContentLength()));
} catch (AmazonS3Exception ex) {
    return null;
}

```

