### PR TITLE
Fix unit test

### DIFF
--- a/embulk-input-s3/src/test/java/org/embulk/input/s3/TestAwsCredentials.java
+++ b/embulk-input-s3/src/test/java/org/embulk/input/s3/TestAwsCredentials.java
@@ -1,13 +1,14 @@
 package org.embulk.input.s3;
 
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.auth.policy.Policy;
 import com.amazonaws.auth.policy.Resource;
 import com.amazonaws.auth.policy.Statement;
 import com.amazonaws.auth.policy.actions.S3Actions;
-import com.amazonaws.internal.StaticCredentialsProvider;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 import com.amazonaws.services.securitytoken.model.Credentials;
 import com.amazonaws.services.securitytoken.model.GetFederationTokenRequest;
 import com.amazonaws.services.securitytoken.model.GetFederationTokenResult;
@@ -148,8 +149,9 @@ public class TestAwsCredentials
 
     private static BasicSessionCredentials getSessionCredentials()
     {
-        AWSSecurityTokenServiceClient stsClient = new AWSSecurityTokenServiceClient(
-                new StaticCredentialsProvider(new BasicAWSCredentials(EMBULK_S3_TEST_ACCESS_KEY_ID, EMBULK_S3_TEST_SECRET_ACCESS_KEY)));
+        AWSSecurityTokenService stsClient = AWSSecurityTokenServiceClientBuilder.standard().withCredentials(
+                new AWSStaticCredentialsProvider(new BasicAWSCredentials(EMBULK_S3_TEST_ACCESS_KEY_ID, EMBULK_S3_TEST_SECRET_ACCESS_KEY))
+        ).build();
 
         GetFederationTokenRequest getFederationTokenRequest = new GetFederationTokenRequest();
         getFederationTokenRequest.setDurationSeconds(7200);

--- a/embulk-input-s3/src/test/java/org/embulk/input/s3/TestS3InputStreamReopener.java
+++ b/embulk-input-s3/src/test/java/org/embulk/input/s3/TestS3InputStreamReopener.java
@@ -1,6 +1,6 @@
 package org.embulk.input.s3;
 
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3Object;
@@ -27,12 +27,12 @@ public class TestS3InputStreamReopener
     @Rule
     public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
 
-    private AmazonS3Client client;
+    private AmazonS3 client;
 
     @Before
     public void createResources()
     {
-        client = mock(AmazonS3Client.class);
+        client = mock(AmazonS3.class);
     }
 
     @Test


### PR DESCRIPTION
Follow up for https://github.com/embulk/embulk-input-s3/pull/59

We upgraded AWS SDK before and I added some minor fix for unit test. 
*  Mock `com.amazonaws.services.s3.AmazonS3` instead of `com.amazonaws.services.s3.AmazonS3Client`
* Remove deprecated method to create AWSSecurityTokenServiceClient
  