### PR TITLE
Add Bintray settings for embulk-input-s3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,9 @@ subprojects {
             script "${project.projectDir.absolutePath}/build/gemspec"
             doLast { ant.move(file: "${project.name}-${project.version}.gem", todir: "${parent.projectDir}/pkg") }
 	}
-    } else {
+    }
+
+    if (![project(":embulk-input-riak_cs")].contains(project)) {
         // publishing
         publishing {
             publications {


### PR DESCRIPTION
I added Bintray settings to publish embulk-input-s3.jar to [Bintray](https://bintray.com/embulk-input-s3/maven/embulk-input-s3) like [embulk-util-aws-credentials](https://bintray.com/embulk-input-s3/maven/embulk-util-aws-credentials/)

In some cases, I'm using embulk-util-aws-credentials as library and I also want to use embulk-input-s3.

Although, I've not uploaded to Bintray with my change, it seems to work.
```shell
* What went wrong:
Execution failed for task ':embulk-util-aws-credentials:bintrayUpload'.
> Could not upload to 'https://api.bintray.com/content/embulk-input-s3/maven/embulk-util-aws-credentials/0.2.12/org/embulk/input/s3/embulk-util-aws-credentials/0.2.12/embulk-util-aws-credentials-0.2.12.jar': HTTP/1.1 409 Conflict [message:Unable to upload files: An artifact with the path 'org/embulk/input/s3/embulk-util-aws-credentials/0.2.12/embulk-util-aws-credentials-0.2.12.jar' already exists]
```