### PR TITLE
Enable Riak CS jar artifact publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,26 +95,24 @@ subprojects {
         }
     }
 
-    if (![project(":embulk-input-riak_cs")].contains(project)) {
-        // publishing
-        publishing {
-            publications {
-                 mavenJava(MavenPublication) {
-                     from components.java
-                     artifact testsJar
-                     artifact sourcesJar
-                     artifact javadocJar
-                     pom.withXml {
-                         asNode().dependencies.dependency.findAll() {
-                             it.scope.text() == 'runtime' && project.configurations.compile.allDependencies.find { dep ->
-                                 dep.name == it.artifactId.text()
-                             }
-                         }.each() {
-                             it.scope*.value = 'compile'
+    // publishing
+    publishing {
+        publications {
+             mavenJava(MavenPublication) {
+                 from components.java
+                 artifact testsJar
+                 artifact sourcesJar
+                 artifact javadocJar
+                 pom.withXml {
+                     asNode().dependencies.dependency.findAll() {
+                         it.scope.text() == 'runtime' && project.configurations.compile.allDependencies.find { dep ->
+                             dep.name == it.artifactId.text()
                          }
+                     }.each() {
+                         it.scope*.value = 'compile'
                      }
                  }
-            }
+             }
         }
     }
     // add tests/javadoc/source jar tasks as artifacts to be released


### PR DESCRIPTION
Also publish Riak CS along with other subproject artifacts to give a chance for further customization on Riak CS Input Plugin if needed.