### PR TITLE
Allow the option to directly read path prefix object instead of listing all objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 - **path_prefix** prefix of target keys (string, required)
 
+- **direct_path_prefix_object** flag to enable treating `path_prefix` as a single object key (boolean, default to `false`). Since list-objects operation on S3 is eventually consistent, using this for a  more reliable way to retrieve a single object when you know the exact object key.
+
 - **endpoint** S3 endpoint login user name (string, optional)
 
 - **region** S3 region. endpoint will be in effect if you specify both of endpoint and region (string, optional)

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
@@ -6,9 +6,11 @@ import com.amazonaws.Protocol;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.ListObjectsRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.s3.model.StorageClass;
@@ -79,6 +81,10 @@ public abstract class AbstractS3FileInputPlugin
         @Config("skip_glacier_objects")
         @ConfigDefault("false")
         public boolean getSkipGlacierObjects();
+
+        @Config("direct_path_prefix_object")
+        @ConfigDefault("false")
+        public boolean getDirectPathPrefixObject();
 
         // TODO timeout, ssl, etc
 
@@ -220,8 +226,13 @@ public abstract class AbstractS3FileInputPlugin
             }
 
             FileList.Builder builder = new FileList.Builder(task);
-            listS3FilesByPrefix(builder, client, bucketName,
-                    task.getPathPrefix(), task.getLastPath(), task.getSkipGlacierObjects());
+            if (!task.getDirectPathPrefixObject()) {
+                listS3FilesByPrefix(builder, client, bucketName,
+                        task.getPathPrefix(), task.getLastPath(), task.getSkipGlacierObjects());
+            }
+            else {
+                addS3DirectObject(builder, client, task.getBucket(), task.getPathPrefix());
+            }
             LOGGER.info("Found total [{}] files", builder.size());
             return builder.build();
         }
@@ -239,6 +250,13 @@ public abstract class AbstractS3FileInputPlugin
         catch (InterruptedException | RetryGiveupException ex) {
             throw new RuntimeException(ex);
         }
+    }
+
+    private void addS3DirectObject(FileList.Builder builder, AmazonS3 client, String bucket, String objectKey)
+    {
+        GetObjectMetadataRequest objectMetadataRequest = new GetObjectMetadataRequest(bucket, objectKey);
+        ObjectMetadata objectMetadata = client.getObjectMetadata(objectMetadataRequest);
+        builder.add(objectKey, objectMetadata.getContentLength());
     }
 
     /**

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
@@ -82,6 +82,12 @@ public abstract class AbstractS3FileInputPlugin
         @ConfigDefault("false")
         public boolean getSkipGlacierObjects();
 
+        /**
+         * When this is on, "path_prefix" config will be treated as a single object key,
+         *
+         * Since list-objects operation on S3 is eventually consistent, using this for a
+         * more reliable way to retrieve a single object when you know the exact object key.
+         */
         @Config("direct_path_prefix_object")
         @ConfigDefault("false")
         public boolean getDirectPathPrefixObject();

--- a/embulk-input-s3/src/test/java/org/embulk/input/s3/TestS3FileInputPlugin.java
+++ b/embulk-input-s3/src/test/java/org/embulk/input/s3/TestS3FileInputPlugin.java
@@ -162,6 +162,17 @@ public class TestS3FileInputPlugin
     }
 
     @Test
+    public void useDirectPathPrefixObject()
+    {
+        ConfigSource config = this.config.deepCopy()
+                .set("direct_path_prefix_object", true)
+                .set("path_prefix", String.format("%s/sample_01.csv", EMBULK_S3_TEST_PATH_PREFIX));
+        ConfigDiff configDiff = runner.transaction(config, new Control(runner, output));
+        assertEquals(String.format("%s/sample_01.csv", EMBULK_S3_TEST_PATH_PREFIX), configDiff.get(String.class, "last_path"));
+        assertEquals(2, getRecords(config, output).size());
+    }
+
+    @Test
     public void configuredEndpoint()
     {
         S3PluginTask task = config.deepCopy()


### PR DESCRIPTION
**Context:**
`ListObject` sometimes is not stable when object is just uploaded, and in that case I'd like to get 1 object instead of list all of objects from `path_prefix`, hence I put the option to get 1 object from `path_prefix` instead of list all and by default ListObject will be used.