### PR TITLE
update getting single object by using path instead of boolean configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - **path_prefix** prefix of target keys (string, optional)
 
 - **path** the direct path to target key (string, optional)
-  - **Note:** Either **path** or *path_prefix** must exist, both is able to exist at the same time and **path** will be chosen in case it's happen
+  - **Note:** Either **path** or *path_prefix** must exist, both is able to exist at the same time and **path** will be chosen in case it happens
 
 - **endpoint** S3 endpoint login user name (string, optional)
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@
 
 - **bucket** S3 bucket name (string, required)
 
-- **path_prefix** prefix of target keys (string, required)
+- **path_prefix** prefix of target keys (string, optional)
 
-- **direct_path_prefix_object** flag to enable treating `path_prefix` as a single object key (boolean, default to `false`). Since list-objects operation on S3 is eventually consistent, using this for a  more reliable way to retrieve a single object when you know the exact object key.
+- **path** the direct path to target key (string, optional)
+  - **Note:** Either **path** or *path_prefix** must exist, both is able to exist at the same time and **path** will be chosen in case it's happen
 
 - **endpoint** S3 endpoint login user name (string, optional)
 

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
@@ -256,7 +256,8 @@ public abstract class AbstractS3FileInputPlugin
         }
     }
 
-    private void addS3DirectObject(final FileList.Builder builder, final AmazonS3 client, final String bucket, final String objectKey) throws RetryGiveupException, InterruptedException {
+    @VisibleForTesting
+    public void addS3DirectObject(final FileList.Builder builder, final AmazonS3 client, final String bucket, final String objectKey) throws RetryGiveupException, InterruptedException {
         // TODO: basic retry solution, should be updated once PR: https://github.com/embulk/embulk-input-s3/pull/72 get merged
         ObjectMetadata objectMetadata = S3FileInputUtils.executeWithRetry(5, 1000, 30 * 1000, new S3FileInputUtils.AlwaysRetryRetryable<ObjectMetadata>()
         {

--- a/embulk-input-s3/src/test/java/org/embulk/input/s3/TestAbstractS3FileInputPlugin.java
+++ b/embulk-input-s3/src/test/java/org/embulk/input/s3/TestAbstractS3FileInputPlugin.java
@@ -1,0 +1,71 @@
+package org.embulk.input.s3;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.embulk.EmbulkTestRuntime;
+import org.embulk.spi.util.RetryExecutor;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+
+public class TestAbstractS3FileInputPlugin {
+    private static AbstractS3FileInputPlugin dummyS3Plugin()
+    {
+        return new AbstractS3FileInputPlugin()
+        {
+            @Override
+            protected Class<? extends PluginTask> getTaskClass()
+            {
+                return PluginTask.class;
+            }
+        };
+    }
+
+    private static class SomeException extends RuntimeException
+    {
+    }
+
+    @Rule
+    public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
+
+    private AmazonS3 client;
+
+    @Before
+    public void setUp() {
+        client = mock(AmazonS3.class);
+    }
+
+    @Test
+    public void addS3DirectObjectShouldRunWithoutRetry() throws RetryExecutor.RetryGiveupException, InterruptedException {
+        doReturn(new ObjectMetadata()).when(client).getObjectMetadata(any(GetObjectMetadataRequest.class));
+        FileList.Builder builder = new FileList.Builder().pathMatchPattern("");
+        dummyS3Plugin().addS3DirectObject(builder, client, "some_bucket", "some_prefix");
+    }
+
+    @Test
+    public void addS3DirectObjectShouldRetryFirstTimeWhenHavingException() throws RetryExecutor.RetryGiveupException, InterruptedException {
+        doThrow(new RuntimeException()).doReturn(new ObjectMetadata())
+                .when(client).getObjectMetadata(any(GetObjectMetadataRequest.class));
+        FileList.Builder builder = new FileList.Builder().pathMatchPattern("");
+        dummyS3Plugin().addS3DirectObject(
+                builder, client, "some_bucket", "some_prefix");
+        verify(client, times(2)).getObjectMetadata(any(GetObjectMetadataRequest.class));
+    }
+
+    @Test(expected = RetryExecutor.RetryGiveupException.class)
+    public void addS3DirectObjectShouldThrowExceptionWhenGaveUp() throws RetryExecutor.RetryGiveupException, InterruptedException {
+        doThrow(new SomeException()).when(client).getObjectMetadata(any(GetObjectMetadataRequest.class));
+        FileList.Builder builder = new FileList.Builder().pathMatchPattern("");
+        dummyS3Plugin().addS3DirectObject(
+                builder, client, "some_bucket", "some_prefix");
+    }
+}

--- a/embulk-input-s3/src/test/java/org/embulk/input/s3/TestS3FileInputPlugin.java
+++ b/embulk-input-s3/src/test/java/org/embulk/input/s3/TestS3FileInputPlugin.java
@@ -162,14 +162,25 @@ public class TestS3FileInputPlugin
     }
 
     @Test
-    public void useDirectPathPrefixObject()
+    public void usePath()
     {
         ConfigSource config = this.config.deepCopy()
-                .set("direct_path_prefix_object", true)
-                .set("path_prefix", String.format("%s/sample_01.csv", EMBULK_S3_TEST_PATH_PREFIX));
+                .set("path", String.format("%s/sample_01.csv", EMBULK_S3_TEST_PATH_PREFIX))
+                .set("path_prefix", null);
         ConfigDiff configDiff = runner.transaction(config, new Control(runner, output));
         assertEquals(String.format("%s/sample_01.csv", EMBULK_S3_TEST_PATH_PREFIX), configDiff.get(String.class, "last_path"));
-        assertEquals(2, getRecords(config, output).size());
+        assertRecords(config, output);
+    }
+
+    @Test
+    public void usePathAsHighPriorityThanPathPrefix()
+    {
+        ConfigSource config = this.config.deepCopy()
+                .set("path", String.format("%s/sample_01.csv", EMBULK_S3_TEST_PATH_PREFIX))
+                .set("path_prefix", "foo"); // path_prefix has the bad value, if path_prefix is chosen, expected result will be failed
+        ConfigDiff configDiff = runner.transaction(config, new Control(runner, output));
+        assertEquals(String.format("%s/sample_01.csv", EMBULK_S3_TEST_PATH_PREFIX), configDiff.get(String.class, "last_path"));
+        assertRecords(config, output);
     }
 
     @Test


### PR DESCRIPTION
The follow-up of previous PR: https://github.com/embulk/embulk-input-s3/pull/71 which updates to use `path` directly instead of using `path_prefix` + boolean configuration.

What remaining in this PR:
* ~~Update UT for new logic~~
* ~~Update README for new input configuration~~