### PR TITLE
Only support Java8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,8 +59,8 @@ subprojects {
         compile.exclude group: 'commons-logging', module: 'commons-logging'   // commons-logging api is provided by jcl-over-slf4j
     }
 
-    sourceCompatibility = 1.7
-    targetCompatibility = 1.7
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 
     dependencies {
         compile  "org.embulk:embulk-core:0.8.18"


### PR DESCRIPTION
Updated (source|target)Compatibility in build.gradle
.travis.yml update isn't necessary. We have already been checking only with Java8.
https://github.com/embulk/embulk-input-s3/blob/master/.travis.yml