### PR TITLE
Use file name output feature in Embulk core to show file name instead of logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,15 +63,15 @@ subprojects {
     targetCompatibility = 1.8
 
     dependencies {
-        compile  "org.embulk:embulk-core:0.9.11"
-        provided "org.embulk:embulk-core:0.9.11"
+        compile  "org.embulk:embulk-core:0.9.12"
+        provided "org.embulk:embulk-core:0.9.12"
         compile "com.amazonaws:aws-java-sdk-s3:1.11.466"
         runtime "org.slf4j:jcl-over-slf4j:1.7.12"  // aws-sdk uses Apache Commons Logging and Embulk uses slf4j
         testCompile "com.amazonaws:aws-java-sdk-sts:1.11.466"
         testCompile "junit:junit:4.+"
         testCompile "org.mockito:mockito-core:1.+"
-        testCompile "org.embulk:embulk-standards:0.9.11"
-        testCompile "org.embulk:embulk-core:0.9.11:tests"
+        testCompile "org.embulk:embulk-standards:0.9.12"
+        testCompile "org.embulk:embulk-core:0.9.12:tests"
     }
 
     gradle.projectsEvaluated {

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
@@ -464,7 +464,7 @@ public abstract class AbstractS3FileInputPlugin
             if (!iterator.hasNext()) {
                 return null;
             }
-            String key = iterator.next();
+            final String key = iterator.next();
             final GetObjectRequest request = new GetObjectRequest(bucket, key);
 
             S3Object object = new DefaultRetryable<S3Object>(format("Getting object '%s'", request.getKey())) {


### PR DESCRIPTION
~Don't merge until new version Embulk is released that contains https://github.com/embulk/embulk/pull/1066~

We're currently implements logging logic for each FileInput plugin.
With https://github.com/embulk/embulk/pull/1066, we can delegate such logic to Embulk core.

This PR is reference implementation to use that logic by plugin. 

