### PR TITLE
Update embulk version and use `java.util.Optional` and `java.util.function.Function`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,15 +63,15 @@ subprojects {
     targetCompatibility = 1.8
 
     dependencies {
-        compile  "org.embulk:embulk-core:0.8.18"
-        provided "org.embulk:embulk-core:0.8.18"
+        compile  "org.embulk:embulk-core:0.9.11"
+        provided "org.embulk:embulk-core:0.9.11"
         compile "com.amazonaws:aws-java-sdk-s3:1.11.253"
         runtime "org.slf4j:jcl-over-slf4j:1.7.12"  // aws-sdk uses Apache Commons Logging and Embulk uses slf4j
         testCompile "com.amazonaws:aws-java-sdk-sts:1.11.253"
         testCompile "junit:junit:4.+"
         testCompile "org.mockito:mockito-core:1.+"
-        testCompile "org.embulk:embulk-standards:0.8.18"
-        testCompile "org.embulk:embulk-core:0.8.18:tests"
+        testCompile "org.embulk:embulk-standards:0.9.11"
+        testCompile "org.embulk:embulk-core:0.9.11:tests"
     }
 
     gradle.projectsEvaluated {

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
@@ -17,7 +17,6 @@ import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.s3.model.StorageClass;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Optional;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigDiff;
@@ -42,6 +41,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 
 import static java.lang.String.format;
 import static org.embulk.spi.util.RetryExecutor.retryExecutor;
@@ -130,7 +130,7 @@ public abstract class AbstractS3FileInputPlugin
         // last_path
         if (task.getIncremental()) {
             Optional<String> lastPath = task.getFiles().getLastPath(task.getLastPath());
-            LOGGER.info("Incremental job, setting last_path to [{}]", lastPath.orNull());
+            LOGGER.info("Incremental job, setting last_path to [{}]", lastPath.orElse(""));
             configDiff.set("last_path", lastPath);
         }
         return configDiff;
@@ -336,7 +336,7 @@ public abstract class AbstractS3FileInputPlugin
                                            boolean skipGlacierObjects,
                                            RetryExecutor retryExec)
     {
-        String lastKey = lastPath.orNull();
+        String lastKey = lastPath.orElse(null);
         do {
             final String finalLastKey = lastKey;
             final ListObjectsRequest req = new ListObjectsRequest(bucketName, prefix, finalLastKey, null, 1024);

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/FileList.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/FileList.java
@@ -3,7 +3,6 @@ package org.embulk.input.s3;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 
 import org.embulk.config.Config;
@@ -23,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -179,7 +179,7 @@ public class FileList
             catch (IOException ex) {
                 throw Throwables.propagate(ex);
             }
-            return new FileList(binary.toByteArray(), getSplits(entries), Optional.fromNullable(last));
+            return new FileList(binary.toByteArray(), getSplits(entries), Optional.ofNullable(last));
         }
 
         private List<List<Entry>> getSplits(List<Entry> all)

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/HttpProxy.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/HttpProxy.java
@@ -1,9 +1,10 @@
 package org.embulk.input.s3;
 
-import com.google.common.base.Optional;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.Task;
+
+import java.util.Optional;
 
 /**
  * HttpProxy is config unit for Input/Output plugins' configs.

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/S3FileInputPlugin.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/S3FileInputPlugin.java
@@ -3,11 +3,12 @@ package org.embulk.input.s3;
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import com.google.common.base.Optional;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.spi.Exec;
 import org.slf4j.Logger;
+
+import java.util.Optional;
 
 public class S3FileInputPlugin
         extends AbstractS3FileInputPlugin

--- a/embulk-input-s3/src/test/java/org/embulk/input/s3/TestAbstractS3FileInputPlugin.java
+++ b/embulk-input-s3/src/test/java/org/embulk/input/s3/TestAbstractS3FileInputPlugin.java
@@ -6,13 +6,14 @@ import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import com.amazonaws.services.s3.model.ListObjectsRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.google.common.base.Optional;
 import org.apache.http.HttpStatus;
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.spi.util.RetryExecutor;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import java.util.Optional;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;

--- a/embulk-input-s3/src/test/java/org/embulk/input/s3/TestHttpProxy.java
+++ b/embulk-input-s3/src/test/java/org/embulk/input/s3/TestHttpProxy.java
@@ -1,12 +1,13 @@
 package org.embulk.input.s3;
 
-import com.google.common.base.Optional;
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigSource;
 import org.embulk.input.s3.S3FileInputPlugin.S3PluginTask;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -41,7 +42,7 @@ public class TestHttpProxy
             String host = "my_host";
             ConfigSource conf = config.deepCopy().set("host", host);
             HttpProxy httpProxy = conf.loadConfig(HttpProxy.class);
-            assertHttpProxy(host, Optional.<Integer>absent(), true, Optional.<String>absent(), Optional.<String>absent(),
+            assertHttpProxy(host, Optional.empty(), true, Optional.empty(), Optional.empty(),
                     httpProxy);
         }
 
@@ -51,7 +52,7 @@ public class TestHttpProxy
                     .set("host", host)
                     .set("https", true);
             HttpProxy httpProxy = conf.loadConfig(HttpProxy.class);
-            assertHttpProxy(host, Optional.<Integer>absent(), true, Optional.<String>absent(), Optional.<String>absent(),
+            assertHttpProxy(host, Optional.empty(), true, Optional.empty(), Optional.empty(),
                     httpProxy);
         }
 
@@ -61,7 +62,7 @@ public class TestHttpProxy
                     .set("host", host)
                     .set("https", false);
             HttpProxy httpProxy = conf.loadConfig(HttpProxy.class);
-            assertHttpProxy(host, Optional.<Integer>absent(), false, Optional.<String>absent(), Optional.<String>absent(),
+            assertHttpProxy(host, Optional.empty(), false, Optional.empty(), Optional.empty(),
                     httpProxy);
         }
 
@@ -72,7 +73,7 @@ public class TestHttpProxy
                     .set("host", host)
                     .set("port", port);
             HttpProxy httpProxy = conf.loadConfig(HttpProxy.class);
-            assertHttpProxy(host, Optional.of(port), true, Optional.<String>absent(), Optional.<String>absent(),
+            assertHttpProxy(host, Optional.of(port), true, Optional.empty(), Optional.empty(),
                     httpProxy);
         }
 

--- a/embulk-input-s3/src/test/java/org/embulk/input/s3/TestS3FileInputPlugin.java
+++ b/embulk-input-s3/src/test/java/org/embulk/input/s3/TestS3FileInputPlugin.java
@@ -6,7 +6,6 @@ import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.Region;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.s3.model.StorageClass;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.embulk.EmbulkTestRuntime;
@@ -31,6 +30,7 @@ import org.mockito.Mockito;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.embulk.input.s3.S3FileInputPlugin.S3PluginTask;
 import static org.junit.Assert.assertEquals;
@@ -235,7 +235,7 @@ public class TestS3FileInputPlugin
         doReturn(s3objectList("in/aa/a", StorageClass.Glacier)).when(client).listObjects(any(ListObjectsRequest.class));
 
         AbstractS3FileInputPlugin plugin = Mockito.mock(AbstractS3FileInputPlugin.class, Mockito.CALLS_REAL_METHODS);
-        plugin.listS3FilesByPrefix(newFileList(config, "sample_00", 100L), client, "test_bucket", "test_prefix", Optional.<String>absent(), false);
+        plugin.listS3FilesByPrefix(newFileList(config, "sample_00", 100L), client, "test_bucket", "test_prefix", Optional.empty(), false);
     }
 
     private FileList.Builder newFileList(ConfigSource config, Object... nameAndSize)

--- a/embulk-util-aws-credentials/src/main/java/org/embulk/util/aws/credentials/AwsCredentials.java
+++ b/embulk-util-aws-credentials/src/main/java/org/embulk/util/aws/credentials/AwsCredentials.java
@@ -13,11 +13,11 @@ import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.auth.profile.ProfilesConfigFile;
-import com.google.common.base.Optional;
 import org.embulk.config.ConfigException;
 import org.embulk.spi.Exec;
-import org.embulk.spi.unit.LocalFile;
 import org.slf4j.Logger;
+
+import java.util.Optional;
 
 public abstract class AwsCredentials
 {
@@ -108,7 +108,7 @@ public abstract class AwsCredentials
                 reject(task.getSecretAccessKey(), secretAccessKeyOption);
                 reject(task.getSessionToken(), sessionTokenOption);
 
-                String profileName = task.getProfileName().or("default");
+                String profileName = task.getProfileName().orElse("default");
                 ProfileCredentialsProvider provider;
                 if (task.getProfileFile().isPresent()) {
                     ProfilesConfigFile file = new ProfilesConfigFile(task.getProfileFile().get().getFile());
@@ -117,8 +117,8 @@ public abstract class AwsCredentials
                 else {
                     provider = new ProfileCredentialsProvider(profileName);
                 }
-                task.setProfileName(Optional.<String>absent());
-                task.setProfileFile(Optional.<LocalFile>absent());
+                task.setProfileName(Optional.empty());
+                task.setProfileFile(Optional.empty());
 
                 return overwriteBasicCredentials(task, provider.getCredentials());
             }

--- a/embulk-util-aws-credentials/src/main/java/org/embulk/util/aws/credentials/AwsCredentialsConfig.java
+++ b/embulk-util-aws-credentials/src/main/java/org/embulk/util/aws/credentials/AwsCredentialsConfig.java
@@ -1,7 +1,8 @@
 package org.embulk.util.aws.credentials;
 
-import com.google.common.base.Optional;
 import org.embulk.spi.unit.LocalFile;
+
+import java.util.Optional;
 
 public interface AwsCredentialsConfig
 {

--- a/embulk-util-aws-credentials/src/main/java/org/embulk/util/aws/credentials/AwsCredentialsTask.java
+++ b/embulk-util-aws-credentials/src/main/java/org/embulk/util/aws/credentials/AwsCredentialsTask.java
@@ -1,9 +1,10 @@
 package org.embulk.util.aws.credentials;
 
-import com.google.common.base.Optional;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.spi.unit.LocalFile;
+
+import java.util.Optional;
 
 public interface AwsCredentialsTask
     extends AwsCredentialsConfig

--- a/embulk-util-aws-credentials/src/main/java/org/embulk/util/aws/credentials/AwsCredentialsTaskWithPrefix.java
+++ b/embulk-util-aws-credentials/src/main/java/org/embulk/util/aws/credentials/AwsCredentialsTaskWithPrefix.java
@@ -1,9 +1,10 @@
 package org.embulk.util.aws.credentials;
 
-import com.google.common.base.Optional;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.spi.unit.LocalFile;
+
+import java.util.Optional;
 
 public interface AwsCredentialsTaskWithPrefix
     extends AwsCredentialsConfig


### PR DESCRIPTION
Same with https://github.com/embulk/embulk-input-sftp/pull/36

* Update Embulk version from 0.8.18 to 0.9.11
* Use `java.util.Optional` and `java.util.function.Function` instead of `com.google.common.base.Optional` and `com.google.common.base.Function`
  * Recent version of Embulk use `java.util.Optional`
* minor fix for logging - show key file path instead of unclear message