### PR TITLE
Restore "max connection" and "socket timeout" settings to prevent SocketTimeoutException

### DIFF
--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
@@ -180,11 +180,10 @@ public abstract class AbstractS3FileInputPlugin
     {
         ClientConfiguration clientConfig = new ClientConfiguration();
 
-        /** PLT-9886: disable built-in retry*/
         //clientConfig.setProtocol(Protocol.HTTP);
-//        clientConfig.setMaxConnections(50); // SDK default: 50
+        clientConfig.setMaxConnections(50); // SDK default: 50
 //        clientConfig.setMaxErrorRetry(3); // SDK default: 3
-//        clientConfig.setSocketTimeout(8 * 60 * 1000); // SDK default: 50*1000
+        clientConfig.setSocketTimeout(8 * 60 * 1000); // SDK default: 50*1000
         clientConfig.setRetryPolicy(PredefinedRetryPolicies.NO_RETRY_POLICY);
         // set http proxy
         if (task.getHttpProxy().isPresent()) {


### PR DESCRIPTION
We've removed `ClientConfiguration.setSocketTimeout()` and `ClientConfiguration.setMaxConnections()` between v0.2.0 to v0.3.0 to improve retry logic. 
* PR https://github.com/embulk/embulk-input-s3/pull/74
* Change https://github.com/embulk/embulk-input-s3/commit/40f4c82fda754f386e3c44822b8694b4e4ef35dc#diff-6bf6730afed89d21ba77d97065bace32R185

However, this cause many `SocketTimeoutException`.
I don't think these 2 parameter are directly related with retry logic.
Then, I'd like to restore these settings.

## Stacktrace before fix
```
2019-01-15 13:14:31.627 +0000 [WARN] (0034:task-0001): S3 read failed. Retrying GET request with 364,042 bytes offset
java.net.SocketTimeoutException: Read timed out
	at java.net.SocketInputStream.socketRead0(Native Method) ~[na:1.8.0_152]
	at java.net.SocketInputStream.socketRead(SocketInputStream.java:116) ~[na:1.8.0_152]
	at java.net.SocketInputStream.read(SocketInputStream.java:171) ~[na:1.8.0_152]
	at java.net.SocketInputStream.read(SocketInputStream.java:141) ~[na:1.8.0_152]
	at sun.security.ssl.InputRecord.readFully(InputRecord.java:465) ~[na:1.8.0_152]
	at sun.security.ssl.InputRecord.readV3Record(InputRecord.java:593) ~[na:1.8.0_152]
	at sun.security.ssl.InputRecord.read(InputRecord.java:532) ~[na:1.8.0_152]
	at sun.security.ssl.SSLSocketImpl.readRecord(SSLSocketImpl.java:983) ~[na:1.8.0_152]
	at sun.security.ssl.SSLSocketImpl.readDataRecord(SSLSocketImpl.java:940) ~[na:1.8.0_152]
	at sun.security.ssl.AppInputStream.read(AppInputStream.java:105) ~[na:1.8.0_152]
	at org.apache.http.impl.io.SessionInputBufferImpl.streamRead(SessionInputBufferImpl.java:137) ~[httpcore-4.3.3.jar:4.3.3]
	at org.apache.http.impl.io.SessionInputBufferImpl.read(SessionInputBufferImpl.java:198) ~[httpcore-4.3.3.jar:4.3.3]
	at org.apache.http.impl.io.ContentLengthInputStream.read(ContentLengthInputStream.java:176) ~[httpcore-4.3.3.jar:4.3.3]
	at org.apache.http.conn.EofSensorInputStream.read(EofSensorInputStream.java:135) ~[httpclient-4.3.6.jar:4.3.6]
	at com.amazonaws.internal.SdkFilterInputStream.read(SdkFilterInputStream.java:90) ~[aws-java-sdk-core-1.10.74.jar:na]
	at com.amazonaws.event.ProgressInputStream.read(ProgressInputStream.java:180) ~[aws-java-sdk-core-1.10.74.jar:na]
	at com.amazonaws.internal.SdkFilterInputStream.read(SdkFilterInputStream.java:90) ~[aws-java-sdk-core-1.10.74.jar:na]
	at com.amazonaws.internal.SdkFilterInputStream.read(SdkFilterInputStream.java:90) ~[aws-java-sdk-core-1.10.74.jar:na]
	at com.amazonaws.internal.SdkFilterInputStream.read(SdkFilterInputStream.java:90) ~[aws-java-sdk-core-1.10.74.jar:na]
	at com.amazonaws.event.ProgressInputStream.read(ProgressInputStream.java:180) ~[aws-java-sdk-core-1.10.74.jar:na]
	at java.security.DigestInputStream.read(DigestInputStream.java:161) ~[na:1.8.0_152]
	at com.amazonaws.services.s3.internal.DigestValidationInputStream.read(DigestValidationInputStream.java:59) ~[aws-java-sdk-s3-1.10.74.jar:na]
	at com.amazonaws.internal.SdkFilterInputStream.read(SdkFilterInputStream.java:90) ~[aws-java-sdk-core-1.10.74.jar:na]
	at com.amazonaws.services.s3.internal.S3AbortableInputStream.read(S3AbortableInputStream.java:125) ~[na:na]
	at com.amazonaws.internal.SdkFilterInputStream.read(SdkFilterInputStream.java:90) ~[aws-java-sdk-core-1.10.74.jar:na]
	at org.embulk.spi.util.ResumableInputStream.read(ResumableInputStream.java:77) ~[embulk-core-0.9.12.jar:0.9.12]
	at org.embulk.spi.util.InputStreamFileInput.poll(InputStreamFileInput.java:151) [embulk-core-0.9.12.jar:0.9.12]
	at org.embulk.spi.util.FileInputInputStream.nextBuffer(FileInputInputStream.java:80) [embulk-core-0.9.12.jar:0.9.12]
	at org.embulk.spi.util.FileInputInputStream.read(FileInputInputStream.java:48) [embulk-core-0.9.12.jar:0.9.12]
	at java.util.zip.InflaterInputStream.fill(InflaterInputStream.java:238) [na:1.8.0_152]
	at java.util.zip.InflaterInputStream.read(InflaterInputStream.java:158) [na:1.8.0_152]
	at java.util.zip.GZIPInputStream.read(GZIPInputStream.java:117) [na:1.8.0_152]
	at org.embulk.spi.util.InputStreamFileInput.poll(InputStreamFileInput.java:151) [embulk-core-0.9.12.jar:0.9.12]
	at org.embulk.spi.util.FileInputInputStream.nextBuffer(FileInputInputStream.java:80) [embulk-core-0.9.12.jar:0.9.12]
	at org.embulk.spi.util.FileInputInputStream.read(FileInputInputStream.java:48) [embulk-core-0.9.12.jar:0.9.12]
	at com.fasterxml.jackson.core.json.UTF8StreamJsonParser.loadMore(UTF8StreamJsonParser.java:180) [jackson-core-2.6.7.jar:2.6.7]
	at com.fasterxml.jackson.core.base.ParserBase.loadMoreGuaranteed(ParserBase.java:459) [jackson-core-2.6.7.jar:2.6.7]
	at com.fasterxml.jackson.core.json.UTF8StreamJsonParser._finishString2(UTF8StreamJsonParser.java:2434) [jackson-core-2.6.7.jar:2.6.7]
	at com.fasterxml.jackson.core.json.UTF8StreamJsonParser._finishAndReturnString(UTF8StreamJsonParser.java:2414) [jackson-core-2.6.7.jar:2.6.7]
	at com.fasterxml.jackson.core.json.UTF8StreamJsonParser.getText(UTF8StreamJsonParser.java:285) [jackson-core-2.6.7.jar:2.6.7]
	at org.embulk.spi.json.JsonParser$AbstractParseContext.jsonTokenToValue(JsonParser.java:153) [embulk-core-0.9.12.jar:0.9.12]
	at org.embulk.spi.json.JsonParser$AbstractParseContext.jsonTokenToValue(JsonParser.java:202) [embulk-core-0.9.12.jar:0.9.12]
	at org.embulk.spi.json.JsonParser$AbstractParseContext.jsonTokenToValue(JsonParser.java:202) [embulk-core-0.9.12.jar:0.9.12]
	at org.embulk.spi.json.JsonParser$AbstractParseContext.jsonTokenToValue(JsonParser.java:202) [embulk-core-0.9.12.jar:0.9.12]
	at org.embulk.spi.json.JsonParser$AbstractParseContext.next(JsonParser.java:123) [embulk-core-0.9.12.jar:0.9.12]
```
