### PR TITLE
Revert log format change to show loaded file name

### DIFF
--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
@@ -475,6 +475,9 @@ public abstract class AbstractS3FileInputPlugin
             }.executeWithCheckedException(retryExec, IOException.class);
 
             long objectSize = object.getObjectMetadata().getContentLength();
+            // Some plugin users are parsing this output to get file list.
+            // Keep it for now but might be removed in the future.
+            LOGGER.info("Open S3Object with bucket [{}], key [{}], with size [{}]", bucket, key, objectSize);
             InputStream inputStream = new ResumableInputStream(object.getObjectContent(), new S3InputStreamReopener(client, request, objectSize, retryExec));
             return new InputStreamWithHints(inputStream, String.format("s3://%s/%s", bucket, key));
         }


### PR DESCRIPTION
At https://github.com/embulk/embulk-input-s3/pull/78/files#diff-6bf6730afed89d21ba77d97065bace32L478 , We obsoleted log output that shows loaded file name.

However, we found some plugin users are parsing this log output to get file list.
Personally, this does make no sense. Log isn't a feature, this is just a log.

As a temporal workaround, I reverted this log format change.

This output format might be changed in the future.
```
Open S3Object with bucket [example-s3-bucket], key [csv/nozip_sample_01.csv], with size [204]
```