### PR TITLE
Disabled to set "PredefinedRetryPolicies.NO_RETRY_POLICY" to prevent "The target server failed to respond" failure

### DIFF
--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java
@@ -184,7 +184,6 @@ public abstract class AbstractS3FileInputPlugin
         clientConfig.setMaxConnections(50); // SDK default: 50
 //        clientConfig.setMaxErrorRetry(3); // SDK default: 3
         clientConfig.setSocketTimeout(8 * 60 * 1000); // SDK default: 50*1000
-        clientConfig.setRetryPolicy(PredefinedRetryPolicies.NO_RETRY_POLICY);
         // set http proxy
         if (task.getHttpProxy().isPresent()) {
             setHttpProxyInAwsClient(clientConfig, task.getHttpProxy().get());


### PR DESCRIPTION
Follow up for #83 

In #83, We reverted `clientConfig.setMaxConnections(50);` changes to reduce `SocketTimeoutException` that had been happening since v0.3.1. This fix worked well and `SocketTimeoutException` doesn't happen for now.

However, we still have another problem. 
Plugin sometimes show `Getting object '/path/to/file.csv' failed. Retrying 1/7 after 30 seconds. Message: Unable to execute HTTP request: The target server failed to respond`
As a result, Embulk execution time becomes long.

Although I couldn't reproduce this problem, I suppose disabled AWS SDK retry that was added at #74 [40f4c82#diff-6bf6730afed89d21ba77d97065bace32R185](https://github.com/embulk/embulk-input-s3/commit/40f4c82fda754f386e3c44822b8694b4e4ef35dc#diff-6bf6730afed89d21ba77d97065bace32R185) is the cause.

I'd also like to revert this change.