### PR TITLE
Change `initial_retry_interval_millis` value from 30 sec to 2 sec

### DIFF
--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/RetrySupportPluginTask.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/RetrySupportPluginTask.java
@@ -11,7 +11,7 @@ public interface RetrySupportPluginTask extends Task
     int getMaximumRetries();
 
     @Config("initial_retry_interval_millis")
-    @ConfigDefault("30000")
+    @ConfigDefault("2000")
     int getInitialRetryIntervalMillis();
 
     @Config("maximum_retry_interval_millis")


### PR DESCRIPTION
Follow up for #83 

In #83, We reverted `clientConfig.setMaxConnections(50);` changes to reduce `SocketTimeoutException` that had been happening since v0.3.1. This fix worked well and `SocketTimeoutException` doesn't happen for now.

However, we still have another problem. 
Plugin sometimes show `Getting object '/path/to/file.csv' failed. Retrying 1/7 after 30 seconds. Message: Unable to execute HTTP request: The target server failed to respond`
As a result, Embulk execution time becomes long.

I noticed `initial_retry_interval_millis` was set to 30 sec at https://github.com/embulk/embulk-input-s3/pull/72/files#diff-32018826f992b0768ea85811b0cc8946R13

This seems too long. I think 2 sec is appropriate.
