### PR TITLE
Enable aws-java-sdk-sts to use profile auth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ subprojects {
         provided "org.embulk:embulk-core:0.9.12"
         compile "com.amazonaws:aws-java-sdk-s3:1.11.466"
         runtime "org.slf4j:jcl-over-slf4j:1.7.12"  // aws-sdk uses Apache Commons Logging and Embulk uses slf4j
-        testCompile "com.amazonaws:aws-java-sdk-sts:1.11.466"
+        runtime "com.amazonaws:aws-java-sdk-sts:1.11.466"
         testCompile "junit:junit:4.+"
         testCompile "org.mockito:mockito-core:1.+"
         testCompile "org.embulk:embulk-standards:0.9.12"


### PR DESCRIPTION
Please fix this error.
* Error: To use assume role profiles the aws-java-sdk-sts module must be on the class path.
* java.lang.ClassNotFoundException: com.amazonaws.services.securitytoken.internal.STSProfileCredentialsService
When I'm trying to use profile auth

it seems class are only enabled in testCompile.
this PR does not tested yet. this is just suggestion proposal.

## command

```
$ embulk guess input.yml
```

## configuration

```
$ cat input.yml
in:
  type: s3
  bucket: example
  path_prefix: test
  endpoint: s3-us-east-1.amazonaws.com
  auth_method: profile
  profile_name: dev-test
```

## error message

```
2019-11-08 13:53:13.354 +0900 [INFO] (main): Started Embulk v0.9.19
2019-11-08 13:53:13.410 +0900 [INFO] (0001:guess): Loaded plugin embulk-input-s3 (0.3.4)
com.amazonaws.SdkClientException: To use assume role profiles the aws-java-sdk-sts module must be on the class path.
	at com.amazonaws.auth.profile.internal.securitytoken.STSProfileCredentialsServiceProvider.getProfileCredentialService(STSProfileCredentialsServiceProvider.java:56)
	at com.amazonaws.auth.profile.internal.securitytoken.STSProfileCredentialsServiceProvider.getProfileCredentialsProvider(STSProfileCredentialsServiceProvider.java:38)
	at com.amazonaws.auth.profile.internal.securitytoken.STSProfileCredentialsServiceProvider.getCredentials(STSProfileCredentialsServiceProvider.java:71)
	at com.amazonaws.auth.profile.internal.ProfileAssumeRoleCredentialsProvider.getCredentials(ProfileAssumeRoleCredentialsProvider.java:51)
	at com.amazonaws.auth.profile.ProfilesConfigFile.getCredentials(ProfilesConfigFile.java:162)
	at com.amazonaws.auth.profile.ProfileCredentialsProvider.getCredentials(ProfileCredentialsProvider.java:161)
	at org.embulk.util.aws.credentials.AwsCredentials.getAWSCredentialsProvider(AwsCredentials.java:123)
	at org.embulk.util.aws.credentials.AwsCredentials.getAWSCredentialsProvider(AwsCredentials.java:35)
	at org.embulk.input.s3.AbstractS3FileInputPlugin.getCredentialsProvider(AbstractS3FileInputPlugin.java:208)
	at org.embulk.input.s3.AbstractS3FileInputPlugin.defaultS3ClientBuilder(AbstractS3FileInputPlugin.java:202)
	at org.embulk.input.s3.S3FileInputPlugin.newS3Client(S3FileInputPlugin.java:43)
	at org.embulk.input.s3.AbstractS3FileInputPlugin.listFiles(AbstractS3FileInputPlugin.java:268)
	at org.embulk.input.s3.AbstractS3FileInputPlugin.transaction(AbstractS3FileInputPlugin.java:136)
	at org.embulk.spi.FileInputRunner.transaction(FileInputRunner.java:62)
	at org.embulk.exec.SamplingParserPlugin.runFileInputSampling(SamplingParserPlugin.java:47)
	at org.embulk.spi.FileInputRunner.guess(FileInputRunner.java:80)
	at org.embulk.exec.GuessExecutor.doGuess(GuessExecutor.java:108)
	at org.embulk.exec.GuessExecutor.access$000(GuessExecutor.java:32)
	at org.embulk.exec.GuessExecutor$1.run(GuessExecutor.java:81)
	at org.embulk.exec.GuessExecutor$1.run(GuessExecutor.java:78)
	at org.embulk.spi.Exec.doWith(Exec.java:22)
	at org.embulk.exec.GuessExecutor.guess(GuessExecutor.java:78)
	at org.embulk.EmbulkEmbed.guess(EmbulkEmbed.java:183)
	at org.embulk.EmbulkRunner.guessInternal(EmbulkRunner.java:203)
	at org.embulk.EmbulkRunner.guess(EmbulkRunner.java:60)
	at org.embulk.cli.EmbulkRun.runSubcommand(EmbulkRun.java:427)
	at org.embulk.cli.EmbulkRun.run(EmbulkRun.java:90)
	at org.embulk.cli.Main.main(Main.java:64)
Caused by: java.lang.ClassNotFoundException: com.amazonaws.services.securitytoken.internal.STSProfileCredentialsService
	at org.embulk.plugin.PluginClassLoader.loadClass(PluginClassLoader.java:161)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:264)
	at com.amazonaws.auth.profile.internal.securitytoken.STSProfileCredentialsServiceProvider.getProfileCredentialService(STSProfileCredentialsServiceProvider.java:53)
	... 27 more

Error: To use assume role profiles the aws-java-sdk-sts module must be on the class path.
```