### PR TITLE
Use OpenJDK8 instead of Oracle JDK8 to fix CI failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 script:
 - ./gradlew --info check jacocoTestReport


### PR DESCRIPTION
Travis CI is failing during the Oracle JDK8 install process.
Let's use OpenJDK8 instead of Oracle JDK8.

```sh
$ export JAVA_HOME=~/oraclejdk8
$ export PATH="$JAVA_HOME/bin:$PATH"
$ ~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"
Ignoring license option: BCL -- using GPLv2+CE by default
install-jdk.sh 2019-10-16
Expected feature release number in range of 9 to 14, but got: 8
The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during 
```

https://travis-ci.org/embulk/embulk-input-s3/builds/609078052