### PR TITLE
Fix auth_method:profile failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,8 +66,8 @@ subprojects {
         compile  "org.embulk:embulk-core:0.9.12"
         provided "org.embulk:embulk-core:0.9.12"
         compile "com.amazonaws:aws-java-sdk-s3:1.11.466"
+        compile "com.amazonaws:aws-java-sdk-sts:1.11.466"
         runtime "org.slf4j:jcl-over-slf4j:1.7.12"  // aws-sdk uses Apache Commons Logging and Embulk uses slf4j
-        testCompile "com.amazonaws:aws-java-sdk-sts:1.11.466"
         testCompile "junit:junit:4.+"
         testCompile "org.mockito:mockito-core:1.+"
         testCompile "org.embulk:embulk-standards:0.9.12"

--- a/embulk-util-aws-credentials/src/main/java/org/embulk/util/aws/credentials/AwsCredentials.java
+++ b/embulk-util-aws-credentials/src/main/java/org/embulk/util/aws/credentials/AwsCredentials.java
@@ -117,8 +117,6 @@ public abstract class AwsCredentials
                 else {
                     provider = new ProfileCredentialsProvider(profileName);
                 }
-                task.setProfileName(Optional.empty());
-                task.setProfileFile(Optional.empty());
 
                 return overwriteBasicCredentials(task, provider.getCredentials());
             }
@@ -189,9 +187,6 @@ public abstract class AwsCredentials
 
     private static AWSCredentialsProvider overwriteBasicCredentials(AwsCredentialsConfig task, final AWSCredentials creds)
     {
-        task.setAuthMethod("basic");
-        task.setAccessKeyId(Optional.of(creds.getAWSAccessKeyId()));
-        task.setSecretAccessKey(Optional.of(creds.getAWSSecretKey()));
         return new AWSCredentialsProvider() {
             public AWSCredentials getCredentials()
             {


### PR DESCRIPTION
To fix https://github.com/embulk/embulk-input-s3/issues/91 and based on https://github.com/embulk/embulk-input-s3/pull/90

The current logic has 2 problems and `auth_method: profile` isn't currently working.

## "com.amazonaws:aws-java-sdk-sts:1.11.466" module is provided only for test

This module is necessary for `auth_method: profile`. We should use "compile "com.amazonaws:aws-java-sdk-sts:1.11.466". Fixed at efad84d

## Auth setting is reset after AWS S3 client is initially created

This plugin call [S3FileInputPlugin.newS3Client() method](https://github.com/embulk/embulk-input-s3/blob/v0.3.4/embulk-input-s3/src/main/java/org/embulk/input/s3/S3FileInputPlugin.java#L37) not only once but also multiple times from [listFiles() method](https://github.com/embulk/embulk-input-s3/blob/v0.3.4/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java#L268), [SingleFileProvider class](https://github.com/embulk/embulk-input-s3/blob/v0.3.4/embulk-input-s3/src/main/java/org/embulk/input/s3/AbstractS3FileInputPlugin.java#L413) and so on.

With current logic, `profile_name`, `profile_file` and `auth_method` will be overridden or reset with empty value after `S3FileInputPlugin.newS3Client()` is initially called.
https://github.com/embulk/embulk-input-s3/compare/fix-ci-failure...fix-profile-auth?expand=1#diff-6608be4a6caf5e483a37560c154d8babL120-L121

Then, getting a file list would success, getting file contents would fail.

I don't think plugin have to reset these values because the plugin has validation logic for each auth method.
https://github.com/embulk/embulk-input-s3/compare/fix-ci-failure...fix-profile-auth?expand=1#diff-6608be4a6caf5e483a37560c154d8babL107-L109
