### PR TITLE
Use org.embulk:embulk-util-aws-credentials:0.4.0

### DIFF
--- a/embulk-input-riak_cs/build.gradle
+++ b/embulk-input-riak_cs/build.gradle
@@ -7,9 +7,6 @@ description = "Reads files stored on Riak CS"
 repositories {
     mavenCentral()
     jcenter()
-    maven {
-        url "https://dl.bintray.com/embulk-input-s3/maven"
-    }
 }
 
 dependencies {

--- a/embulk-input-riak_cs/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-riak_cs/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -16,6 +16,7 @@ javax.validation:validation-api:1.1.0.Final
 joda-time:joda-time:2.9.2
 org.apache.httpcomponents:httpclient:4.5.5
 org.apache.httpcomponents:httpcore:4.4.9
-org.embulk.input.s3:embulk-util-aws-credentials:0.3.5
+org.embulk:embulk-util-aws-credentials:0.4.0
+org.embulk:embulk-util-config:0.1.1
 org.slf4j:jcl-over-slf4j:1.7.12
 software.amazon.ion:ion-java:1.0.2

--- a/embulk-input-riak_cs/src/main/java/org/embulk/input/riak_cs/RiakCsFileInputPlugin.java
+++ b/embulk-input-riak_cs/src/main/java/org/embulk/input/riak_cs/RiakCsFileInputPlugin.java
@@ -18,7 +18,7 @@ package org.embulk.input.riak_cs;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.services.s3.AmazonS3;
-import org.embulk.config.Config;
+import org.embulk.util.config.Config;
 import org.embulk.input.s3.AbstractS3FileInputPlugin;
 
 import static com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;

--- a/embulk-input-riak_cs/src/test/java/org/embulk/input/riak_cs/TestRiakCsFileInputPlugin.java
+++ b/embulk-input-riak_cs/src/test/java/org/embulk/input/riak_cs/TestRiakCsFileInputPlugin.java
@@ -19,6 +19,9 @@ package org.embulk.input.riak_cs;
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigSource;
 import org.embulk.input.s3.AbstractS3FileInputPlugin.PluginTask;
+import org.embulk.util.config.ConfigMapper;
+import org.embulk.util.config.ConfigMapperFactory;
+import org.embulk.util.config.TaskMapper;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,7 +48,10 @@ public class TestRiakCsFileInputPlugin
                 .set("path_prefix", "my_path_prefix")
                 .set("access_key_id", "my_access_key_id")
                 .set("secret_access_key", "my_secret_access_key");
-        PluginTask task = config.loadConfig(plugin.getTaskClass());
+        final ConfigMapper configMapper = CONFIG_MAPPER_FACTORY.createConfigMapper();
+        final PluginTask task = configMapper.map(config, plugin.getTaskClass());
         plugin.newS3Client(task);
     }
+
+    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder().addDefaultModules().build();
 }

--- a/embulk-input-s3/build.gradle
+++ b/embulk-input-s3/build.gradle
@@ -7,9 +7,6 @@ description = "Reads files stored on Amazon S3"
 repositories {
     mavenCentral()
     jcenter()
-    maven {
-        url "https://dl.bintray.com/embulk-input-s3/maven"
-    }
 }
 
 dependencies {
@@ -48,10 +45,15 @@ dependencies {
         exclude group: "org.slf4j", module: "slf4j-api"
     }
 
-    compile("org.embulk.input.s3:embulk-util-aws-credentials:0.3.5") {
+    compile("org.embulk:embulk-util-aws-credentials:0.4.0") {
         // They conflict with embulk-core. They are once excluded here,
         // and added explicitly with versions exactly the same with embulk-core:0.10.5.
-        exclude group: "*"
+        exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
+        exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
+        exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
+        exclude group: "com.fasterxml.jackson.datatype", module: "jackson-datatype-jdk8"
+        exclude group: "javax.validation", module: "validation-api"
+        exclude group: "joda-time", module: "joda-time"
     }
 
     // They are once excluded from transitive dependencies of other dependencies,

--- a/embulk-input-s3/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-s3/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -16,6 +16,7 @@ javax.validation:validation-api:1.1.0.Final
 joda-time:joda-time:2.9.2
 org.apache.httpcomponents:httpclient:4.5.5
 org.apache.httpcomponents:httpcore:4.4.9
-org.embulk.input.s3:embulk-util-aws-credentials:0.3.5
+org.embulk:embulk-util-aws-credentials:0.4.0
+org.embulk:embulk-util-config:0.1.1
 org.slf4j:jcl-over-slf4j:1.7.12
 software.amazon.ion:ion-java:1.0.2

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/FileList.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/FileList.java
@@ -20,9 +20,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import org.embulk.config.Config;
-import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigSource;
+import org.embulk.util.config.Config;
+import org.embulk.util.config.ConfigDefault;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/HttpProxy.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/HttpProxy.java
@@ -16,9 +16,9 @@
 
 package org.embulk.input.s3;
 
-import org.embulk.config.Config;
-import org.embulk.config.ConfigDefault;
-import org.embulk.config.Task;
+import org.embulk.util.config.Config;
+import org.embulk.util.config.ConfigDefault;
+import org.embulk.util.config.Task;
 
 import java.util.Optional;
 

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/RetrySupportPluginTask.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/RetrySupportPluginTask.java
@@ -16,9 +16,9 @@
 
 package org.embulk.input.s3;
 
-import org.embulk.config.Config;
-import org.embulk.config.ConfigDefault;
-import org.embulk.config.Task;
+import org.embulk.util.config.Config;
+import org.embulk.util.config.ConfigDefault;
+import org.embulk.util.config.Task;
 
 public interface RetrySupportPluginTask extends Task
 {

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/S3FileInputPlugin.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/S3FileInputPlugin.java
@@ -19,8 +19,8 @@ package org.embulk.input.s3;
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import org.embulk.config.Config;
-import org.embulk.config.ConfigDefault;
+import org.embulk.util.config.Config;
+import org.embulk.util.config.ConfigDefault;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/embulk-input-s3/src/test/java/org/embulk/input/s3/TestHttpProxy.java
+++ b/embulk-input-s3/src/test/java/org/embulk/input/s3/TestHttpProxy.java
@@ -19,6 +19,9 @@ package org.embulk.input.s3;
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigSource;
 import org.embulk.input.s3.S3FileInputPlugin.S3PluginTask;
+import org.embulk.util.config.ConfigMapper;
+import org.embulk.util.config.ConfigMapperFactory;
+import org.embulk.util.config.TaskMapper;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,17 +50,19 @@ public class TestHttpProxy
     {
         ConfigSource conf = config.deepCopy();
         setupS3Config(conf);
-        S3PluginTask task = conf.loadConfig(S3PluginTask.class);
+        final ConfigMapper configMapper = CONFIG_MAPPER_FACTORY.createConfigMapper();
+        final S3PluginTask task = configMapper.map(config, S3PluginTask.class);
         assertTrue(!task.getHttpProxy().isPresent());
     }
 
     @Test
     public void checkHttpProxy()
     {
+        final ConfigMapper configMapper = CONFIG_MAPPER_FACTORY.createConfigMapper();
         { // specify host
             String host = "my_host";
             ConfigSource conf = config.deepCopy().set("host", host);
-            HttpProxy httpProxy = conf.loadConfig(HttpProxy.class);
+            final HttpProxy httpProxy = configMapper.map(conf, HttpProxy.class);
             assertHttpProxy(host, Optional.empty(), true, Optional.empty(), Optional.empty(),
                     httpProxy);
         }
@@ -67,7 +72,7 @@ public class TestHttpProxy
             ConfigSource conf = config.deepCopy()
                     .set("host", host)
                     .set("https", true);
-            HttpProxy httpProxy = conf.loadConfig(HttpProxy.class);
+            final HttpProxy httpProxy = configMapper.map(conf, HttpProxy.class);
             assertHttpProxy(host, Optional.empty(), true, Optional.empty(), Optional.empty(),
                     httpProxy);
         }
@@ -77,7 +82,7 @@ public class TestHttpProxy
             ConfigSource conf = config.deepCopy()
                     .set("host", host)
                     .set("https", false);
-            HttpProxy httpProxy = conf.loadConfig(HttpProxy.class);
+            final HttpProxy httpProxy = configMapper.map(conf, HttpProxy.class);
             assertHttpProxy(host, Optional.empty(), false, Optional.empty(), Optional.empty(),
                     httpProxy);
         }
@@ -88,7 +93,7 @@ public class TestHttpProxy
             ConfigSource conf = config.deepCopy()
                     .set("host", host)
                     .set("port", port);
-            HttpProxy httpProxy = conf.loadConfig(HttpProxy.class);
+            final HttpProxy httpProxy = configMapper.map(conf, HttpProxy.class);
             assertHttpProxy(host, Optional.of(port), true, Optional.empty(), Optional.empty(),
                     httpProxy);
         }
@@ -103,7 +108,7 @@ public class TestHttpProxy
                     .set("port", port)
                     .set("user", user)
                     .set("password", password);
-            HttpProxy httpProxy = conf.loadConfig(HttpProxy.class);
+            final HttpProxy httpProxy = configMapper.map(conf, HttpProxy.class);
             assertHttpProxy(host, Optional.of(port), true, Optional.of(user), Optional.of(password),
                     httpProxy);
         }
@@ -134,4 +139,6 @@ public class TestHttpProxy
             assertEquals(password.get(), actual.getPassword().get());
         }
     }
+
+    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder().addDefaultModules().build();
 }


### PR DESCRIPTION
It starts to use the updated `embulk-util-aws-credentials:0.4.0` extracted to https://github.com/embulk/embulk-util-aws-credentials from this repository.

The biggest change here is that it starts to to use `embulk-util-config` to process Embulk configs, instead of `ConfigSource#loadConfig` and, `TaskSource#loadTask`.

To mitigate the impact, this will be out in the version `0.4.1` separate from `0.4.0`.