### PR TITLE
Update to Embulk v0.10.18, and not to depend on "embulk-core"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-embulk-input-s3 v0.3.0+ requires Embulk v0.9.12+
+embulk-input-s3 v0.5.0+ requires Embulk v0.9.23+
 
 * Plugin type: **file input**
 * Resume supported: **yes**

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ plugins {
     id "org.embulk.embulk-plugins" version "0.4.2" apply false
 }
 
-group = "org.embulk.input.s3"
-version = "0.4.1-SNAPSHOT"
+group = "org.embulk"
+version = "0.5.0-SNAPSHOT"
 
 allprojects {
     apply plugin: "java"

--- a/embulk-input-riak_cs/build.gradle
+++ b/embulk-input-riak_cs/build.gradle
@@ -10,12 +10,13 @@ repositories {
 }
 
 dependencies {
-    compileOnly "org.embulk:embulk-api:0.10.5"
-    compileOnly "org.embulk:embulk-core:0.10.5"
+    compileOnly "org.embulk:embulk-api:0.10.18"
+    compileOnly "org.embulk:embulk-spi:0.10.18"
+    // No longer need to depend on "embulk-core"!
 
     compile(project(":embulk-input-s3")) {
         // They conflict with embulk-core. They are once excluded here,
-        // and added explicitly with versions exactly the same with embulk-core:0.10.5.
+        // and added explicitly with versions exactly the same with embulk-core:0.10.18.
         exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
         exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
         exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
@@ -25,7 +26,7 @@ dependencies {
     }
 
     // They are once excluded from transitive dependencies of other dependencies,
-    // and added explicitly with versions exactly the same with embulk-core:0.10.5.
+    // and added explicitly with versions exactly the same with embulk-core:0.10.18.
     compile "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
     compile "com.fasterxml.jackson.core:jackson-core:2.6.7"
     compile "com.fasterxml.jackson.core:jackson-databind:2.6.7"
@@ -35,13 +36,12 @@ dependencies {
 
     testCompile "junit:junit:4.13"
     testCompile "org.mockito:mockito-core:1.10.19"
-    testCompile "org.embulk:embulk-api:0.10.5"
-    testCompile "org.embulk:embulk-core:0.10.5"
-    testCompile "org.embulk:embulk-core:0.10.5:tests"
-    testCompile "org.embulk:embulk-deps-buffer:0.10.5"
-    testCompile "org.embulk:embulk-deps-config:0.10.5"
-    testCompile "org.embulk:embulk-deps-timestamp:0.10.5"
-    testCompile "org.embulk:embulk-standards:0.10.5"
+    testCompile "org.embulk:embulk-api:0.10.18"
+    testCompile "org.embulk:embulk-spi:0.10.18"
+    testCompile "org.embulk:embulk-core:0.10.18"
+    testCompile "org.embulk:embulk-core:0.10.18:tests"
+    testCompile "org.embulk:embulk-deps:0.10.18"
+    testCompile "org.embulk:embulk-standards:0.10.18"
     testCompile project(":embulk-input-s3").sourceSets.test.output
 }
 
@@ -49,17 +49,7 @@ embulkPlugin {
     mainClass = "org.embulk.input.riak_cs.RiakCsFileInputPlugin"
     category = "input"
     type = "riak_cs"
-    ignoreConflicts = [
-        // They conflict with embulk-core:0.10.5, but embulk-core will remove them from its dependencies.
-        // They are intentionally included in the plugin's dependencies to keep it working before and after the removal.
-        // Warning messages against them are marked to ignore explicitly here.
-        [ group: "com.fasterxml.jackson.core", module: "jackson-annotations" ],
-        [ group: "com.fasterxml.jackson.core", module: "jackson-core" ],
-        [ group: "com.fasterxml.jackson.core", module: "jackson-databind" ],
-        [ group: "com.fasterxml.jackson.datatype", module: "jackson-datatype-jdk8" ],
-        [ group: "javax.validation", module: "validation-api" ],
-        [ group: "joda-time", module: "joda-time" ],
-    ]
+    // "ignoreConflicts" is no longer needed because this plugin depends only on "embulk-api" and "embulk-spi".
 }
 
 gem {

--- a/embulk-input-riak_cs/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-riak_cs/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -17,6 +17,8 @@ joda-time:joda-time:2.9.2
 org.apache.httpcomponents:httpclient:4.5.5
 org.apache.httpcomponents:httpcore:4.4.9
 org.embulk:embulk-util-aws-credentials:0.4.0
-org.embulk:embulk-util-config:0.1.1
+org.embulk:embulk-util-config:0.1.3
+org.embulk:embulk-util-file:0.1.1
+org.embulk:embulk-util-retryhelper:0.8.0
 org.slf4j:jcl-over-slf4j:1.7.12
 software.amazon.ion:ion-java:1.0.2

--- a/embulk-input-s3/build.gradle
+++ b/embulk-input-s3/build.gradle
@@ -10,12 +10,12 @@ repositories {
 }
 
 dependencies {
-    compileOnly "org.embulk:embulk-api:0.10.5"
-    compileOnly "org.embulk:embulk-core:0.10.5"
+    compileOnly "org.embulk:embulk-api:0.10.18"
+    compileOnly "org.embulk:embulk-spi:0.10.18"
 
     compile("com.amazonaws:aws-java-sdk-s3:1.11.466") {
         // They conflict with embulk-core. They are once excluded here,
-        // and added explicitly with versions exactly the same with embulk-core:0.10.5.
+        // and added explicitly with versions exactly the same with embulk-core:0.10.18.
         exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
         exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
         exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
@@ -27,7 +27,7 @@ dependencies {
 
     compile("com.amazonaws:aws-java-sdk-sts:1.11.466") {
         // They conflict with embulk-core. They are once excluded here,
-        // and added explicitly with versions exactly the same with embulk-core:0.10.5.
+        // and added explicitly with versions exactly the same with embulk-core:0.10.18.
         exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
         exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
         exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
@@ -45,9 +45,13 @@ dependencies {
         exclude group: "org.slf4j", module: "slf4j-api"
     }
 
+    compile "org.embulk:embulk-util-retryhelper:0.8.0"
+
+    compile "org.embulk:embulk-util-file:0.1.1"
+
     compile("org.embulk:embulk-util-aws-credentials:0.4.0") {
         // They conflict with embulk-core. They are once excluded here,
-        // and added explicitly with versions exactly the same with embulk-core:0.10.5.
+        // and added explicitly with versions exactly the same with embulk-core:0.10.18.
         exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
         exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
         exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
@@ -56,8 +60,18 @@ dependencies {
         exclude group: "joda-time", module: "joda-time"
     }
 
+    compile("org.embulk:embulk-util-config:0.1.3") {
+        // They conflict with embulk-core. They are once excluded here,
+        // and added explicitly with versions exactly the same with embulk-core:0.10.18.
+        exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
+        exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
+        exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
+        exclude group: "com.fasterxml.jackson.datatype", module: "jackson-datatype-jdk8"
+        exclude group: "javax.validation", module: "validation-api"
+    }
+
     // They are once excluded from transitive dependencies of other dependencies,
-    // and added explicitly with versions exactly the same with embulk-core:0.10.5.
+    // and added explicitly with versions exactly the same with embulk-core:0.10.18.
     compile "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
     compile "com.fasterxml.jackson.core:jackson-core:2.6.7"
     compile "com.fasterxml.jackson.core:jackson-databind:2.6.7"
@@ -67,30 +81,19 @@ dependencies {
 
     testCompile "junit:junit:4.13"
     testCompile "org.mockito:mockito-core:1.10.19"
-    testCompile "org.embulk:embulk-api:0.10.5"
-    testCompile "org.embulk:embulk-core:0.10.5"
-    testCompile "org.embulk:embulk-core:0.10.5:tests"
-    testCompile "org.embulk:embulk-deps-buffer:0.10.5"
-    testCompile "org.embulk:embulk-deps-config:0.10.5"
-    testCompile "org.embulk:embulk-deps-timestamp:0.10.5"
-    testCompile "org.embulk:embulk-standards:0.10.5"
+    testCompile "org.embulk:embulk-api:0.10.18"
+    testCompile "org.embulk:embulk-spi:0.10.18"
+    testCompile "org.embulk:embulk-core:0.10.18"
+    testCompile "org.embulk:embulk-core:0.10.18:tests"
+    testCompile "org.embulk:embulk-deps:0.10.18"
+    testCompile "org.embulk:embulk-standards:0.10.18"
 }
 
 embulkPlugin {
     mainClass = "org.embulk.input.s3.S3FileInputPlugin"
     category = "input"
     type = "s3"
-    ignoreConflicts = [
-        // They conflict with embulk-core:0.10.5, but embulk-core will remove them from its dependencies.
-        // They are intentionally included in the plugin's dependencies to keep it working before and after the removal.
-        // Warning messages against them are marked to ignore explicitly here.
-        [ group: "com.fasterxml.jackson.core", module: "jackson-annotations" ],
-        [ group: "com.fasterxml.jackson.core", module: "jackson-core" ],
-        [ group: "com.fasterxml.jackson.core", module: "jackson-databind" ],
-        [ group: "com.fasterxml.jackson.datatype", module: "jackson-datatype-jdk8" ],
-        [ group: "javax.validation", module: "validation-api" ],
-        [ group: "joda-time", module: "joda-time" ],
-    ]
+    // "ignoreConflicts" is no longer needed because this plugin depends only on "embulk-api" and "embulk-spi".
 }
 
 gem {

--- a/embulk-input-s3/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-s3/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -17,6 +17,8 @@ joda-time:joda-time:2.9.2
 org.apache.httpcomponents:httpclient:4.5.5
 org.apache.httpcomponents:httpcore:4.4.9
 org.embulk:embulk-util-aws-credentials:0.4.0
-org.embulk:embulk-util-config:0.1.1
+org.embulk:embulk-util-config:0.1.3
+org.embulk:embulk-util-file:0.1.1
+org.embulk:embulk-util-retryhelper:0.8.0
 org.slf4j:jcl-over-slf4j:1.7.12
 software.amazon.ion:ion-java:1.0.2

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/DefaultRetryable.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/DefaultRetryable.java
@@ -18,7 +18,9 @@ package org.embulk.input.s3;
 
 import com.amazonaws.AmazonServiceException;
 import org.apache.http.HttpStatus;
-import org.embulk.spi.util.RetryExecutor;
+import org.embulk.util.retryhelper.RetryExecutor;
+import org.embulk.util.retryhelper.RetryGiveupException;
+import org.embulk.util.retryhelper.Retryable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,8 +29,6 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 
 import static java.lang.String.format;
-import static org.embulk.spi.util.RetryExecutor.RetryGiveupException;
-import static org.embulk.spi.util.RetryExecutor.Retryable;
 
 /**
  * Retryable utility, regardless the occurred exceptions,

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/explorer/S3FileExplorer.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/explorer/S3FileExplorer.java
@@ -18,7 +18,7 @@ package org.embulk.input.s3.explorer;
 
 import com.amazonaws.services.s3.AmazonS3;
 import org.embulk.input.s3.FileList;
-import org.embulk.spi.util.RetryExecutor;
+import org.embulk.util.retryhelper.RetryExecutor;
 
 public abstract class S3FileExplorer
 {

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/explorer/S3NameOrderPrefixFileExplorer.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/explorer/S3NameOrderPrefixFileExplorer.java
@@ -21,7 +21,7 @@ import com.amazonaws.services.s3.model.ListObjectsRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import org.embulk.input.s3.DefaultRetryable;
-import org.embulk.spi.util.RetryExecutor;
+import org.embulk.util.retryhelper.RetryExecutor;
 
 import java.util.List;
 

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/explorer/S3PrefixFileExplorer.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/explorer/S3PrefixFileExplorer.java
@@ -21,7 +21,7 @@ import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.s3.model.StorageClass;
 import org.embulk.config.ConfigException;
 import org.embulk.input.s3.FileList;
-import org.embulk.spi.util.RetryExecutor;
+import org.embulk.util.retryhelper.RetryExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/explorer/S3SingleFileExplorer.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/explorer/S3SingleFileExplorer.java
@@ -21,7 +21,7 @@ import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import org.embulk.input.s3.DefaultRetryable;
 import org.embulk.input.s3.FileList;
-import org.embulk.spi.util.RetryExecutor;
+import org.embulk.util.retryhelper.RetryExecutor;
 
 public class S3SingleFileExplorer extends S3FileExplorer
 {

--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/explorer/S3TimeOrderPrefixFileExplorer.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/explorer/S3TimeOrderPrefixFileExplorer.java
@@ -20,9 +20,8 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ListObjectsRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
-import org.apache.commons.lang3.StringUtils;
 import org.embulk.input.s3.DefaultRetryable;
-import org.embulk.spi.util.RetryExecutor;
+import org.embulk.util.retryhelper.RetryExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,7 +77,7 @@ public class S3TimeOrderPrefixFileExplorer extends S3PrefixFileExplorer
     {
         if (lastPath == null) {
             LOGGER.info("The total number of LIST requests is {}{}.", numOfReq,
-                    numOfReq < 10 ? StringUtils.EMPTY : ". Clean up your s3 bucket to reduce the number of requests and improve the ingesting performance");
+                    numOfReq < 10 ? "" : ". Clean up your s3 bucket to reduce the number of requests and improve the ingesting performance");
             return false;
         }
         return true;

--- a/embulk-input-s3/src/test/java/org/embulk/input/s3/TestS3InputStreamReopener.java
+++ b/embulk-input-s3/src/test/java/org/embulk/input/s3/TestS3InputStreamReopener.java
@@ -24,6 +24,7 @@ import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.input.s3.AbstractS3FileInputPlugin.S3InputStreamReopener;
+import org.embulk.util.retryhelper.RetryExecutor;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,7 +34,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
-import static org.embulk.spi.util.RetryExecutor.retryExecutor;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -78,9 +78,10 @@ public class TestS3InputStreamReopener
                     client,
                     new GetObjectRequest("my_bucket", "in/aa/a"),
                     content.length(),
-                    retryExecutor()
-                            .withInitialRetryWait(0)
-                            .withRetryLimit(1));
+                    RetryExecutor.builder()
+                            .withInitialRetryWaitMillis(0)
+                            .withRetryLimit(1)
+                            .build());
 
             try (InputStream in = opener.reopen(0, new RuntimeException())) {
                 BufferedReader r = new BufferedReader(new InputStreamReader(in));
@@ -99,9 +100,10 @@ public class TestS3InputStreamReopener
                 client,
                 new GetObjectRequest("my_bucket", "in/aa/a"),
                 content.length(),
-                retryExecutor()
-                        .withInitialRetryWait(0)
-                        .withRetryLimit(0));
+                RetryExecutor.builder()
+                        .withInitialRetryWaitMillis(0)
+                        .withRetryLimit(0)
+                        .build());
 
         opener.reopen(0, new RuntimeException());
     }
@@ -116,9 +118,10 @@ public class TestS3InputStreamReopener
                 client,
                 new GetObjectRequest("my_bucket", "in/aa/a"),
                 "value".length(),
-                retryExecutor()
-                        .withInitialRetryWait(0)
-                        .withRetryLimit(2));
+                RetryExecutor.builder()
+                        .withInitialRetryWaitMillis(0)
+                        .withRetryLimit(2)
+                        .build());
 
         try (InputStream in = opener.reopen(0, new AmazonClientException("This exception can be ignored"))) {
             fail("Should throw exception.");

--- a/embulk-input-s3/src/test/java/org/embulk/input/s3/explorer/TestS3PrefixFileExplorer.java
+++ b/embulk-input-s3/src/test/java/org/embulk/input/s3/explorer/TestS3PrefixFileExplorer.java
@@ -22,7 +22,7 @@ import com.amazonaws.services.s3.model.StorageClass;
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigException;
 import org.embulk.input.s3.FileList;
-import org.embulk.spi.util.RetryExecutor;
+import org.embulk.util.retryhelper.RetryExecutor;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;


### PR DESCRIPTION
Along with Embulk v0.10.18,
* Change the Maven artifact group name to "org.embulk"
* Update the version to "0.5.0-SNAPSHOT"
* Update org.embulk:embulk-util-config to "0.1.3" to use its newConfigDiff and newTaskReport
* Use org.embulk:embulk-util-retryhelper instead of org.embulk.spi.util.RetryExecutor
* Use org.embulk:embulk-util-file instead of org.embulk.spi.util.*
* Remove use of commons-lang3