### PR TITLE
Remove unnecessary items, .idea, classpath, and *.gem, from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
 *~
-.idea
 build/
-classpath/
 /.gradle
-/*.gem


### PR DESCRIPTION
After starting to use `gradle-embulk-plugins`, we no longer need `classpath/` and `*.gem` in `.gitignore`. Cleaning them up.