### PR TITLE
Add ability to fetch restored glacier object

### DIFF
--- a/embulk-input-s3/src/main/java/org/embulk/input/s3/explorer/S3NameOrderPrefixFileExplorer.java
+++ b/embulk-input-s3/src/main/java/org/embulk/input/s3/explorer/S3NameOrderPrefixFileExplorer.java
@@ -17,8 +17,10 @@
 package org.embulk.input.s3.explorer;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import com.amazonaws.services.s3.model.ListObjectsRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import org.embulk.input.s3.DefaultRetryable;
 import org.embulk.util.retryhelper.RetryExecutor;
@@ -51,6 +53,17 @@ public class S3NameOrderPrefixFileExplorer extends S3PrefixFileExplorer
         lastPath = ol.getNextMarker();
 
         return ol.getObjectSummaries();
+    }
+
+    @Override
+    protected ObjectMetadata fetchObjectMetadata(S3ObjectSummary obj) {
+        final GetObjectMetadataRequest req = new GetObjectMetadataRequest(obj.getBucketName(), obj.getKey());
+
+        return new DefaultRetryable<ObjectMetadata>("Get object metadata")
+        {
+            @Override
+            public ObjectMetadata call() { return s3Client.getObjectMetadata(req); }
+        }.executeWith(retryExecutor);
     }
 
     @Override


### PR DESCRIPTION
The restored Glacier object has been excluded from loading because the storage class remains Glacier.
This fix will load the Glacier object if it has already been restored.

* Restored object's HeadObject response example
```
{
    "Restore": "ongoing-request=\"false\", expiry-date=\"Sun, 13 Aug 2017 00:00:00 GMT\"",
    ...
    "StorageClass": "GLACIER",
    "Metadata": {}
}
```

* Ongoing restore object's HeadObject response example
```
{
    "Restore": "ongoing-request=\"true\"",
    ...
    "StorageClass": "GLACIER",
    "Metadata": {}
}
```