### PR TITLE
Support S3 Private Link

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 group = "org.embulk"
-version = "0.6.0-SNAPSHOT"
+version = "0.6.1-SNAPSHOT"
 description = "Reads files stored on Amazon S3"
 
 sourceCompatibility = JavaVersion.VERSION_1_8

--- a/src/main/java/org/embulk/input/s3/S3FileInputPlugin.java
+++ b/src/main/java/org/embulk/input/s3/S3FileInputPlugin.java
@@ -481,6 +481,7 @@ public class S3FileInputPlugin
             builder.setEndpointConfiguration(new EndpointConfiguration("s3.amazonaws.com", null));
         }
 
+        builder.withForceGlobalBucketAccessEnabled(true);
         return builder.build();
     }
 


### PR DESCRIPTION
In the current code, If the endpoint is S3 Private Link (e.g: bucket.vpce-1a2b3c4d-5e6f.s3.us-east-1.vpce.amazonaws.com), The plugin can't connect to S3 with below error message
` Message: The authorization header is malformed; the region 'vpce' is wrong; expecting 'us-east-1' (Service: Amazon S3; Status Code: 400; Error Code: AuthorizationHeaderMalformed; Request ID: 4SJFB38TBFE5CP1M; S3 Extended Request ID: lPPhAhTyC9aQO9bF0XMa5wqzaFpVO927JJRexs4HZjj0gzjOeA9rELX++mVWCkmM9kHD2DNhvJE=)`

This PR fixes this issue by enabling `ForceGlobalBucketAccessEnabled`, which will force the SDK to use the region in the exception. (Please refer details in: https://github.com/aws/aws-sdk-java/issues/1107#issuecomment-293022788)