### PR TITLE
Change modifier from private to protected

### DIFF
--- a/src/main/java/org/embulk/input/s3/S3FileInputPlugin.java
+++ b/src/main/java/org/embulk/input/s3/S3FileInputPlugin.java
@@ -198,12 +198,12 @@ public class S3FileInputPlugin
         return new S3FileInput(task, taskIndex);
     }
 
-    private AWSCredentialsProvider getCredentialsProvider(PluginTask task)
+    protected AWSCredentialsProvider getCredentialsProvider(PluginTask task)
     {
         return AwsCredentials.getAWSCredentialsProvider(task);
     }
 
-    private ClientConfiguration getClientConfiguration(PluginTask task)
+    protected ClientConfiguration getClientConfiguration(PluginTask task)
     {
         ClientConfiguration clientConfig = new ClientConfiguration();
 
@@ -443,7 +443,7 @@ public class S3FileInputPlugin
         }
     }
 
-    private AmazonS3 newS3Client(final PluginTask task)
+    protected AmazonS3 newS3Client(final PluginTask task)
     {
         Optional<String> endpoint = task.getEndpoint();
         Optional<String> region = task.getRegion();


### PR DESCRIPTION
In this PR, I propose we change `private` to `protected`, There is some reason for this PR

- Current private methods make it hard to customize
- We add the flexibility for other implementor to overwrite this method
- The old version (0.5.3) uses `protected`, but the newest version changed it to `private`. I think changing back to protected will make it more backward compatible.
